### PR TITLE
ci: remove changelog plugin from semantic-release config

### DIFF
--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -5,6 +5,5 @@ branches:
 plugins:
   - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"
-  - "@semantic-release/changelog"
   - "@semantic-release/github"
   - "@semantic-release/git"


### PR DESCRIPTION
- Remove @semantic-release/changelog from .releaserc.yaml
- Keep commit-analyzer, release-notes-generator, github, and git plugins

🤖 Generated with Claude Code