### PR TITLE
build: remove Meilisearch healthcheck from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,12 +176,6 @@ services:
       - ./data/meili:/meili_data
     environment:
       - MEILI_MASTER_KEY=${MEILI_MASTER_KEY}
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:7700/health"]
-      interval: 15s
-      timeout: 5s
-      retries: 3
-      start_period: 20s
 
 volumes:
   cards_data:


### PR DESCRIPTION
- Remove healthcheck configuration from meilisearch service
- Simplify service startup without health monitoring

🤖 Generated with Claude Code