### PR TITLE
fix: sets ordering, web-app Docker base image, and CI buildcache refs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,8 +100,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/mtg-api/api:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/mtg-api/api:buildcache,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/api:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/api:buildcache,mode=max
 
   docker-build-app:
     name: Build and Push Streamlit App Image
@@ -148,8 +148,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/mtg-api/app:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/mtg-api/app:buildcache,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/app:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/app:buildcache,mode=max
 
   docker-build-web-app:
     name: Build and Push Web App Image
@@ -196,8 +196,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/mtg-api/web-app:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/mtg-api/web-app:buildcache,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/web-app:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/web-app:buildcache,mode=max
 
   docker-build-huey:
     name: Build and Push Huey Worker Image
@@ -244,8 +244,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/mtg-api/huey:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/mtg-api/huey:buildcache,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/huey:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/huey:buildcache,mode=max
 
   docker-build-mcp:
     name: Build and Push MCP Server Image
@@ -292,5 +292,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/mtg-api/mcp:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/mtg-api/mcp:buildcache,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/mcp:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/mcp:buildcache,mode=max

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,13 @@ repos:
         language: system
         files: ^web-app/.*\.(ts|tsx)$
         pass_filenames: false
+      - id: pnpm-lockfile-check
+        name: pnpm lockfile up to date (web-app)
+        # Mirrors the `pnpm install --frozen-lockfile` that CI runs, so a
+        # package.json edit without a matching lockfile update fails here
+        # instead of in the pipeline. Skips resolution when in sync, so it
+        # stays fast and needs no network.
+        entry: bash -c 'cd web-app && pnpm install --lockfile-only --frozen-lockfile'
+        language: system
+        files: ^web-app/(package\.json|pnpm-lock\.yaml)$
+        pass_filenames: false

--- a/api/router/sets.py
+++ b/api/router/sets.py
@@ -29,7 +29,7 @@ def get_sets(collection: CardsCollection) -> Sets:
                         "_id": "$set_name",
                     }
                 },
-                {"$sort": {"_id": -1}},
+                {"$sort": {"_id": 1}},  # 1 for ascending (alphabetical) order
             ]
         )
     ]

--- a/documentation/fastapi-testing-guide.md
+++ b/documentation/fastapi-testing-guide.md
@@ -1,0 +1,605 @@
+# FastAPI Testing Guide - Best Practices (2025)
+
+## Overview
+
+This guide covers modern best practices for testing FastAPI applications using pytest, based on the latest FastAPI documentation and community standards.
+
+## Table of Contents
+
+1. [Testing Approaches](#testing-approaches)
+2. [Basic Setup](#basic-setup)
+3. [TestClient for Synchronous Tests](#testclient-for-synchronous-tests)
+4. [AsyncClient for Async Tests](#asyncclient-for-async-tests)
+5. [Database Testing](#database-testing)
+6. [Dependency Overrides](#dependency-overrides)
+7. [Authentication Testing](#authentication-testing)
+8. [Best Practices](#best-practices)
+
+---
+
+## Testing Approaches
+
+FastAPI supports two main testing approaches:
+
+1. **Unit Tests with Mocking** - Fast, isolated tests that mock dependencies
+2. **Integration Tests with TestClient/AsyncClient** - Test actual HTTP endpoints with real database interactions
+
+### Current State
+
+Our project uses **Unit Tests with Mocking** (see `tests/api/router/test_card_search.py`). This approach is excellent for testing business logic in isolation.
+
+### Recommended Addition
+
+Add **Integration Tests** to complement unit tests, ensuring endpoints work correctly with actual dependencies.
+
+---
+
+## Basic Setup
+
+### Required Dependencies
+
+Already installed in `pyproject.toml`:
+
+```toml
+[project.optional-dependencies]
+tests = [
+    "pytest>=8.3.4",
+    "pytest-asyncio>=0.25.0",
+    "pytest-httpx>=0.35.0",
+    "pytest-cov>=6.0.0",
+]
+```
+
+### Project Structure
+
+```
+tests/
+├── conftest.py              # Shared fixtures
+├── api/
+│   ├── test_integration.py  # Integration tests with TestClient
+│   └── router/
+│       ├── test_cards_integration.py
+│       └── test_card_search.py  # Existing unit tests
+```
+
+---
+
+## TestClient for Synchronous Tests
+
+### Basic Example
+
+```python
+from fastapi.testclient import TestClient
+from api.main import app
+
+client = TestClient(app)
+
+def test_health_check():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}
+```
+
+### Testing with Query Parameters
+
+```python
+def test_search_cards():
+    response = client.get("/cards/search", params={"q": "Lightning Bolt"})
+    assert response.status_code == 200
+    data = response.json()
+    assert "cards" in data
+    assert len(data["cards"]) > 0
+```
+
+### Testing POST Requests
+
+```python
+def test_create_deck():
+    deck_data = {
+        "name": "Red Deck Wins",
+        "cards": ["card-id-1", "card-id-2"]
+    }
+    response = client.post("/decks", json=deck_data)
+    assert response.status_code == 201
+    assert response.json()["name"] == "Red Deck Wins"
+```
+
+### Testing Error Cases
+
+```python
+def test_card_not_found():
+    response = client.get("/cards/id/nonexistent-id")
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+```
+
+---
+
+## AsyncClient for Async Tests
+
+For async endpoints or when testing with async database operations, use `httpx.AsyncClient`.
+
+### Configuration in pytest
+
+Add to `pyproject.toml`:
+
+```toml
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+```
+
+### Basic Async Test
+
+```python
+import pytest
+from httpx import ASGITransport, AsyncClient
+from api.main import app
+
+@pytest.mark.asyncio
+async def test_async_endpoint():
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as ac:
+        response = await ac.get("/cards/search?q=bolt")
+        assert response.status_code == 200
+```
+
+### Fixture Setup
+
+Create `tests/conftest.py`:
+
+```python
+import pytest
+from httpx import ASGITransport, AsyncClient
+from api.main import app
+
+@pytest.fixture(scope="session")
+def anyio_backend():
+    """Tell pytest-asyncio to use asyncio."""
+    return "asyncio"
+
+@pytest.fixture
+async def async_client():
+    """Async client fixture for testing."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as ac:
+        yield ac
+```
+
+### Using Async Fixture
+
+```python
+@pytest.mark.asyncio
+async def test_with_fixture(async_client):
+    response = await async_client.get("/cards/search?q=bolt")
+    assert response.status_code == 200
+```
+
+---
+
+## Database Testing
+
+### Test Database Isolation
+
+**Option 1: Use Test Database**
+
+```python
+import pytest
+from pymongo import MongoClient
+
+@pytest.fixture(scope="function")
+def test_db():
+    """Create test database, yield, then cleanup."""
+    client = MongoClient("mongodb://localhost:27017")
+    db = client["mtg_test_db"]
+
+    # Seed test data
+    db.cards.insert_many([
+        {"id": "test-1", "name": "Lightning Bolt"},
+        {"id": "test-2", "name": "Counterspell"}
+    ])
+
+    yield db
+
+    # Cleanup
+    client.drop_database("mtg_test_db")
+    client.close()
+```
+
+**Option 2: Transaction Rollback**
+
+```python
+@pytest.fixture
+async def test_db_session():
+    """Use transaction rollback for isolation."""
+    async with AsyncSession() as session:
+        async with session.begin():
+            yield session
+            # Transaction auto-rolls back after test
+```
+
+### Override Database Dependency
+
+```python
+from api.main import app
+from api.helpers.database import get_database
+
+def override_get_database():
+    """Return test database."""
+    client = MongoClient("mongodb://localhost:27017")
+    return client["mtg_test_db"]
+
+app.dependency_overrides[get_database] = override_get_database
+```
+
+---
+
+## Dependency Overrides
+
+Dependency overrides allow you to replace real dependencies (database, auth, external APIs) with test implementations.
+
+### Override Authentication
+
+```python
+from api.dependencies.auth import get_current_user
+
+def override_auth():
+    """Skip authentication in tests."""
+    return {"user_id": "test-user", "username": "testuser"}
+
+app.dependency_overrides[get_current_user] = override_auth
+
+def test_protected_endpoint():
+    response = client.get("/protected")
+    assert response.status_code == 200
+```
+
+### Override External API Calls
+
+```python
+from api.dependencies.external import get_scryfall_api
+
+def mock_scryfall():
+    """Mock Scryfall API client."""
+    class MockScryfall:
+        def get_card(self, card_id):
+            return {"id": card_id, "name": "Mock Card"}
+    return MockScryfall()
+
+app.dependency_overrides[get_scryfall_api] = mock_scryfall
+```
+
+### Cleanup After Tests
+
+```python
+@pytest.fixture(autouse=True)
+def cleanup_overrides():
+    """Clear dependency overrides after each test."""
+    yield
+    app.dependency_overrides.clear()
+```
+
+---
+
+## Authentication Testing
+
+### Testing JWT Authentication
+
+```python
+from datetime import datetime, timedelta
+import jwt
+
+def create_test_token(user_id: str = "test-user"):
+    """Create valid JWT token for testing."""
+    payload = {
+        "user_id": user_id,
+        "exp": datetime.utcnow() + timedelta(hours=1)
+    }
+    return jwt.encode(payload, "secret-key", algorithm="HS256")
+
+def test_authenticated_request():
+    token = create_test_token()
+    response = client.get(
+        "/protected",
+        headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == 200
+```
+
+### Testing Unauthorized Access
+
+```python
+def test_no_token():
+    response = client.get("/protected")
+    assert response.status_code == 401
+
+def test_invalid_token():
+    response = client.get(
+        "/protected",
+        headers={"Authorization": "Bearer invalid-token"}
+    )
+    assert response.status_code == 401
+```
+
+---
+
+## Best Practices
+
+### 1. Use Fixtures for Reusable Setup
+
+**Good:**
+```python
+@pytest.fixture
+def sample_cards():
+    return [
+        {"id": "1", "name": "Lightning Bolt"},
+        {"id": "2", "name": "Counterspell"}
+    ]
+
+def test_search(sample_cards):
+    # Use sample_cards fixture
+    pass
+```
+
+**Bad:**
+```python
+def test_search():
+    # Recreate test data in every test
+    cards = [{"id": "1", "name": "Lightning Bolt"}]
+```
+
+### 2. Test Response Structure
+
+```python
+def test_card_response_structure():
+    response = client.get("/cards/id/test-id")
+    data = response.json()
+
+    # Assert response structure
+    assert "id" in data
+    assert "name" in data
+    assert "image_uris" in data
+    assert isinstance(data["image_uris"], dict)
+```
+
+### 3. Use Parametrize for Multiple Cases
+
+```python
+@pytest.mark.parametrize("card_id,expected_name", [
+    ("id-1", "Lightning Bolt"),
+    ("id-2", "Counterspell"),
+    ("id-3", "Giant Growth"),
+])
+def test_get_cards(card_id, expected_name):
+    response = client.get(f"/cards/id/{card_id}")
+    assert response.json()["name"] == expected_name
+```
+
+### 4. Separate Unit and Integration Tests
+
+```python
+# tests/unit/test_card_logic.py - Fast, mocked
+def test_card_filter_logic():
+    # Test pure logic with mocks
+    pass
+
+# tests/integration/test_card_api.py - Slower, real dependencies
+def test_card_api_endpoint():
+    # Test actual HTTP endpoint
+    pass
+```
+
+### 5. Mock External HTTP Calls
+
+```python
+import httpx
+import respx
+
+@respx.mock
+def test_external_api_call():
+    # Mock external API
+    respx.get("https://api.scryfall.com/cards/bolt").mock(
+        return_value=httpx.Response(200, json={"name": "Lightning Bolt"})
+    )
+
+    response = client.get("/cards/fetch/bolt")
+    assert response.status_code == 200
+```
+
+### 6. Test Error Handling
+
+```python
+def test_database_error_handling(monkeypatch):
+    """Test graceful handling of database errors."""
+    def mock_db_error(*args, **kwargs):
+        raise ConnectionError("Database unavailable")
+
+    monkeypatch.setattr("api.helpers.database.collection.find", mock_db_error)
+
+    response = client.get("/cards/search?q=bolt")
+    assert response.status_code == 503  # Service Unavailable
+    assert "database" in response.json()["detail"].lower()
+```
+
+### 7. Use Coverage Reports
+
+```bash
+# Run tests with coverage
+pytest --cov=api --cov-report=html
+
+# View coverage report
+open htmlcov/index.html
+```
+
+### 8. Organize Tests by Feature
+
+```
+tests/
+├── api/
+│   ├── router/
+│   │   ├── test_cards_unit.py          # Unit tests with mocks
+│   │   ├── test_cards_integration.py   # Integration tests
+│   │   ├── test_sets_unit.py
+│   │   └── test_sets_integration.py
+│   └── helpers/
+│       └── test_database.py
+```
+
+---
+
+## Running Tests
+
+```bash
+# Run all tests
+pytest
+
+# Run specific test file
+pytest tests/api/router/test_cards_integration.py
+
+# Run specific test
+pytest tests/api/router/test_cards_integration.py::test_search_endpoint
+
+# Run with verbose output
+pytest -v
+
+# Run with coverage
+pytest --cov=api --cov-report=term-missing
+
+# Run only integration tests
+pytest -m integration
+
+# Run only unit tests
+pytest -m unit
+```
+
+---
+
+## Example: Complete Integration Test
+
+```python
+# tests/api/router/test_cards_integration.py
+import pytest
+from fastapi.testclient import TestClient
+from api.main import app
+
+client = TestClient(app)
+
+@pytest.fixture(scope="module")
+def setup_test_db():
+    """Setup test database with sample data."""
+    # Connect to test database
+    from pymongo import MongoClient
+    client = MongoClient("mongodb://localhost:27017")
+    db = client["mtg_test_db"]
+
+    # Insert test data
+    db.cards.insert_many([
+        {
+            "id": "test-bolt-id",
+            "oracle_id": "oracle-bolt",
+            "name": "Lightning Bolt",
+            "mana_cost": "{R}",
+            "cmc": 1,
+            "colors": ["R"],
+            "type_line": "Instant",
+            "oracle_text": "Lightning Bolt deals 3 damage to any target.",
+            "rarity": "common"
+        },
+        {
+            "id": "test-counter-id",
+            "oracle_id": "oracle-counter",
+            "name": "Counterspell",
+            "mana_cost": "{U}{U}",
+            "cmc": 2,
+            "colors": ["U"],
+            "type_line": "Instant",
+            "oracle_text": "Counter target spell.",
+            "rarity": "uncommon"
+        }
+    ])
+
+    yield db
+
+    # Cleanup
+    client.drop_database("mtg_test_db")
+    client.close()
+
+def test_health_check():
+    """Test basic health check endpoint."""
+    response = client.get("/health")
+    assert response.status_code == 200
+
+def test_search_cards_basic(setup_test_db):
+    """Test basic card search."""
+    response = client.get("/cards/search?q=Lightning")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "cards" in data
+    assert len(data["cards"]) > 0
+    assert data["cards"][0]["name"] == "Lightning Bolt"
+
+def test_search_with_filters(setup_test_db):
+    """Test search with color filter."""
+    response = client.post(
+        "/cards/search",
+        params={"q": "instant"},
+        json={"colors": ["U"], "color_operator": "or"}
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    # Should only return blue cards
+    for card in data["cards"]:
+        assert "U" in card["colors"]
+
+def test_get_card_by_id(setup_test_db):
+    """Test retrieving specific card by Scryfall ID."""
+    response = client.get("/cards/id/test-bolt-id")
+
+    assert response.status_code == 200
+    card = response.json()
+    assert card["name"] == "Lightning Bolt"
+    assert card["cmc"] == 1
+
+def test_card_not_found():
+    """Test 404 for nonexistent card."""
+    response = client.get("/cards/id/nonexistent-id")
+    assert response.status_code == 404
+```
+
+---
+
+## Key Takeaways
+
+1. **Use TestClient** for most endpoint testing - it's fast and doesn't require running the server
+2. **Use AsyncClient** when testing async endpoints or async database operations
+3. **Use dependency overrides** to mock authentication, databases, and external services
+4. **Separate concerns** - unit tests for logic, integration tests for endpoints
+5. **Centralize fixtures** in `conftest.py` for reusability
+6. **Test both success and failure cases** - don't just test the happy path
+7. **Use test databases** to avoid affecting production data
+8. **Run tests in CI/CD** to catch issues early
+
+---
+
+## Next Steps
+
+1. Create `tests/conftest.py` with shared fixtures
+2. Add integration tests alongside existing unit tests
+3. Configure pytest in `pyproject.toml`
+4. Set up test database configuration
+5. Add CI/CD pipeline to run tests automatically
+
+---
+
+## References
+
+- [FastAPI Testing Documentation](https://fastapi.tiangolo.com/tutorial/testing/)
+- [FastAPI Async Tests](https://fastapi.tiangolo.com/advanced/async-tests/)
+- [pytest Documentation](https://docs.pytest.org/)
+- [pytest-asyncio](https://pytest-asyncio.readthedocs.io/)

--- a/documentation/mongodb-mocking-strategy.md
+++ b/documentation/mongodb-mocking-strategy.md
@@ -1,0 +1,1037 @@
+# MongoDB Mocking Strategy for FastAPI Testing
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Mocking Approaches Comparison](#mocking-approaches-comparison)
+3. [Recommended Approach](#recommended-approach)
+4. [Implementation Guide](#implementation-guide)
+5. [mongomock Library](#mongomock-library)
+6. [Custom Mock Implementation](#custom-mock-implementation)
+7. [FastAPI Dependency Injection](#fastapi-dependency-injection)
+8. [Testing Patterns](#testing-patterns)
+9. [Best Practices](#best-practices)
+10. [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+When testing FastAPI applications that use MongoDB, you need to decide how to handle database interactions. This document explores different strategies and provides recommendations based on industry best practices (2025).
+
+### Why Mock MongoDB?
+
+✅ **Faster tests** - No network I/O or disk operations
+✅ **Isolated tests** - No shared state between tests
+✅ **CI/CD friendly** - No need to run MongoDB in CI environment
+✅ **Deterministic** - Consistent test data and behavior
+✅ **Portable** - Tests run anywhere without database setup
+
+### Testing Levels
+
+```
+┌─────────────────────────────────────────────┐
+│ E2E Tests (Real MongoDB)                    │  Slowest, most realistic
+├─────────────────────────────────────────────┤
+│ Integration Tests (mongomock or Test DB)    │  Medium speed, realistic behavior
+├─────────────────────────────────────────────┤
+│ Unit Tests (unittest.mock)                  │  Fastest, test logic only
+└─────────────────────────────────────────────┘
+```
+
+---
+
+## Mocking Approaches Comparison
+
+### 1. mongomock Library
+
+**Description**: In-memory MongoDB implementation with PyMongo-compatible interface
+
+**Pros:**
+- ✅ Drop-in replacement for PyMongo's MongoClient
+- ✅ Supports most common MongoDB operations
+- ✅ No external dependencies or services
+- ✅ Fast execution
+- ✅ Realistic MongoDB behavior
+- ✅ Active maintenance and community support
+
+**Cons:**
+- ❌ Not a perfect MongoDB replica (some features missing)
+- ❌ May behave differently than real MongoDB in edge cases
+- ❌ Doesn't test actual database connectivity
+
+**Best for:** Integration tests where you want realistic MongoDB behavior without running a database
+
+**Example:**
+```python
+import mongomock
+
+# Replace real MongoDB client
+client = mongomock.MongoClient()
+db = client["test_db"]
+collection = db["cards"]
+
+# Use exactly like PyMongo
+collection.insert_one({"name": "Lightning Bolt"})
+result = collection.find_one({"name": "Lightning Bolt"})
+```
+
+### 2. unittest.mock (MagicMock)
+
+**Description**: Python's built-in mocking framework for creating mock objects
+
+**Pros:**
+- ✅ No external dependencies
+- ✅ Full control over mock behavior
+- ✅ Fast execution
+- ✅ Test specific function calls and arguments
+- ✅ Good for testing error handling
+
+**Cons:**
+- ❌ Requires manual setup for each test
+- ❌ Doesn't validate MongoDB query syntax
+- ❌ Tests may pass even if MongoDB queries are wrong
+- ❌ Verbose boilerplate code
+
+**Best for:** Unit tests focusing on business logic rather than database queries
+
+**Example:**
+```python
+from unittest.mock import MagicMock, patch
+
+mock_collection = MagicMock()
+mock_collection.find_one.return_value = {"name": "Lightning Bolt"}
+
+with patch("api.router.cards.collection", mock_collection):
+    result = get_card("bolt")
+    assert result["name"] == "Lightning Bolt"
+```
+
+### 3. Real Test Database
+
+**Description**: Use actual MongoDB instance with separate test database
+
+**Pros:**
+- ✅ 100% realistic behavior
+- ✅ Tests actual database operations
+- ✅ Validates query syntax and performance
+- ✅ No abstraction layer
+
+**Cons:**
+- ❌ Slower test execution
+- ❌ Requires MongoDB installation
+- ❌ Complex CI/CD setup
+- ❌ Cleanup between tests needed
+- ❌ Potential for test pollution
+
+**Best for:** E2E tests and pre-production validation
+
+**Example:**
+```python
+import pytest
+from pymongo import MongoClient
+
+@pytest.fixture
+def test_db():
+    client = MongoClient("mongodb://localhost:27017")
+    db = client["test_db"]
+    yield db
+    client.drop_database("test_db")  # Cleanup
+```
+
+### 4. MockupDB
+
+**Description**: Wire protocol server that mimics MongoDB for testing
+
+**Pros:**
+- ✅ Tests wire protocol level interactions
+- ✅ Simulate connection failures and network issues
+- ✅ Fine-grained control over server responses
+
+**Cons:**
+- ❌ More complex setup
+- ❌ Requires learning specific API
+- ❌ Overkill for most use cases
+
+**Best for:** Testing MongoDB driver behavior and error handling
+
+---
+
+## Recommended Approach
+
+### For This Project: **Hybrid Strategy**
+
+```
+┌──────────────────────────────────────────────┐
+│ Unit Tests (existing)                        │
+│ - unittest.mock for business logic          │
+│ - Fast, focused on algorithms               │
+└──────────────────────────────────────────────┘
+              ↓
+┌──────────────────────────────────────────────┐
+│ Integration Tests (new)                      │
+│ - mongomock for endpoint testing            │
+│ - Realistic MongoDB behavior                │
+│ - Test actual HTTP requests                 │
+└──────────────────────────────────────────────┘
+              ↓
+┌──────────────────────────────────────────────┐
+│ E2E Tests (future/optional)                  │
+│ - Real MongoDB with Docker Compose          │
+│ - Full system testing                       │
+└──────────────────────────────────────────────┘
+```
+
+**Why mongomock for integration tests?**
+
+1. **Realistic behavior** - Tests will catch actual MongoDB query issues
+2. **Fast enough** - Still runs in milliseconds
+3. **Easy setup** - Two-line replacement of MongoClient
+4. **Maintenance** - Active project with good PyMongo compatibility
+5. **CI/CD friendly** - No external services needed
+
+---
+
+## Implementation Guide
+
+### Step 1: Install mongomock
+
+Add to `pyproject.toml`:
+
+```toml
+[project.optional-dependencies]
+tests = [
+    "pytest>=8.3.4",
+    "pytest-asyncio>=0.25.0",
+    "pytest-httpx>=0.35.0",
+    "pytest-cov>=6.0.0",
+    "mongomock>=4.2.0",  # Add this
+]
+```
+
+Install:
+```bash
+uv sync --extra tests
+```
+
+### Step 2: Refactor Database Connection (Dependency Injection)
+
+**Current code** (`api/router/cards.py`):
+```python
+from pymongo import MongoClient
+
+# Module-level connection (hard to mock)
+client = MongoClient(f"mongodb://{DATABASE_USER}:{DATABASE_PASSWORD}@{DATABASE_HOST}:{DATABASE_PORT}")
+db = client[DATABASE]
+collection = db["cards"]
+
+@router.get("/cards/{name}")
+def search_card_by_name(name: str):
+    results = collection.find_one({"name": name})  # Uses global collection
+    return results
+```
+
+**Refactored code** with dependency injection:
+
+Create `api/dependencies/database.py`:
+```python
+from pymongo import MongoClient
+from common.constants import DATABASE, DATABASE_HOST, DATABASE_PASSWORD, DATABASE_PORT, DATABASE_USER
+
+def get_mongo_client():
+    """Get MongoDB client connection.
+
+    This function is a dependency that can be overridden in tests.
+    """
+    return MongoClient(
+        f"mongodb://{DATABASE_USER}:{DATABASE_PASSWORD}@{DATABASE_HOST}:{DATABASE_PORT}"
+    )
+
+def get_database(client: MongoClient = Depends(get_mongo_client)):
+    """Get database instance."""
+    return client[DATABASE]
+
+def get_cards_collection(db = Depends(get_database)):
+    """Get cards collection.
+
+    This dependency can be overridden in tests to use mongomock.
+    """
+    return db["cards"]
+```
+
+Update `api/router/cards.py`:
+```python
+from fastapi import Depends
+from api.dependencies.database import get_cards_collection
+
+@router.get("/cards/{name}")
+def search_card_by_name(
+    name: str,
+    collection = Depends(get_cards_collection)  # Inject collection
+):
+    results = collection.find_one({"name": name})
+    return results
+```
+
+### Step 3: Create Test Fixtures
+
+Create `tests/conftest.py`:
+
+```python
+import pytest
+import mongomock
+from fastapi.testclient import TestClient
+from api.main import app
+from api.dependencies.database import get_cards_collection
+
+@pytest.fixture
+def mock_mongo_collection():
+    """Create a mongomock collection for testing."""
+    client = mongomock.MongoClient()
+    db = client["test_db"]
+    collection = db["cards"]
+    return collection
+
+@pytest.fixture
+def client_with_mock_db(mock_mongo_collection):
+    """TestClient with mocked MongoDB."""
+
+    # Override dependency to use mongomock
+    app.dependency_overrides[get_cards_collection] = lambda: mock_mongo_collection
+
+    client = TestClient(app)
+    yield client
+
+    # Cleanup
+    app.dependency_overrides.clear()
+
+@pytest.fixture
+def sample_cards():
+    """Sample card data for testing."""
+    return [
+        {
+            "id": "test-bolt-id",
+            "oracle_id": "oracle-bolt",
+            "name": "Lightning Bolt",
+            "name_search": "lightning bolt",
+            "mana_cost": "{R}",
+            "cmc": 1,
+            "colors": ["R"],
+            "type_line": "Instant",
+            "oracle_text": "Lightning Bolt deals 3 damage to any target.",
+            "rarity": "common",
+            "set": "lea",
+            "set_name": "Limited Edition Alpha",
+            "lang": "en",
+            "layout": "normal",
+            "released_at": "1993-08-05",
+            "image_uris": {
+                "small": "https://example.com/small.jpg",
+                "normal": "https://example.com/normal.jpg",
+                "large": "https://example.com/large.jpg",
+                "png": "https://example.com/card.png"
+            }
+        },
+        {
+            "id": "test-counter-id",
+            "oracle_id": "oracle-counter",
+            "name": "Counterspell",
+            "name_search": "counterspell",
+            "mana_cost": "{U}{U}",
+            "cmc": 2,
+            "colors": ["U"],
+            "type_line": "Instant",
+            "oracle_text": "Counter target spell.",
+            "rarity": "uncommon",
+            "set": "lea",
+            "set_name": "Limited Edition Alpha",
+            "lang": "en",
+            "layout": "normal",
+            "released_at": "1993-08-05",
+            "image_uris": {
+                "small": "https://example.com/small.jpg",
+                "normal": "https://example.com/normal.jpg",
+                "large": "https://example.com/large.jpg",
+                "png": "https://example.com/card.png"
+            }
+        }
+    ]
+
+@pytest.fixture
+def populated_db(mock_mongo_collection, sample_cards):
+    """MongoDB collection populated with sample cards."""
+    mock_mongo_collection.insert_many(sample_cards)
+
+    # Create text index for search
+    mock_mongo_collection.create_index([("name", "text"), ("oracle_text", "text")])
+
+    return mock_mongo_collection
+```
+
+### Step 4: Write Integration Tests
+
+Create `tests/api/router/test_cards_integration.py`:
+
+```python
+import pytest
+from fastapi.testclient import TestClient
+
+def test_get_card_by_scryfall_id(client_with_mock_db, populated_db):
+    """Test retrieving card by Scryfall ID."""
+    response = client_with_mock_db.get("/cards/id/test-bolt-id")
+
+    assert response.status_code == 200
+    card = response.json()
+    assert card["name"] == "Lightning Bolt"
+    assert card["cmc"] == 1
+    assert card["colors"] == ["R"]
+
+def test_get_card_not_found(client_with_mock_db, populated_db):
+    """Test 404 when card doesn't exist."""
+    response = client_with_mock_db.get("/cards/id/nonexistent-id")
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+def test_search_cards(client_with_mock_db, populated_db):
+    """Test card text search."""
+    response = client_with_mock_db.get("/cards/search/damage")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "cards" in data
+    assert len(data["cards"]) > 0
+    assert data["cards"][0]["name"] == "Lightning Bolt"
+```
+
+---
+
+## mongomock Library
+
+### Installation
+
+```bash
+pip install mongomock
+# or
+uv add --optional tests mongomock
+```
+
+### Basic Usage
+
+```python
+import mongomock
+
+# Create client (in-memory)
+client = mongomock.MongoClient()
+
+# Get database and collection
+db = client["test_db"]
+collection = db["cards"]
+
+# Use exactly like PyMongo
+collection.insert_one({"name": "Lightning Bolt", "cmc": 1})
+collection.insert_many([{"name": "Card 1"}, {"name": "Card 2"}])
+
+# Query operations
+result = collection.find_one({"name": "Lightning Bolt"})
+results = list(collection.find({"cmc": {"$gte": 2}}))
+
+# Aggregation
+pipeline = [
+    {"$match": {"colors": {"$in": ["R"]}}},
+    {"$group": {"_id": "$set_name", "count": {"$sum": 1}}}
+]
+results = list(collection.aggregate(pipeline))
+
+# Indexes
+collection.create_index([("name", "text")])
+```
+
+### Supported Operations
+
+mongomock supports most common MongoDB operations:
+
+**CRUD:**
+- `insert_one()`, `insert_many()`
+- `find()`, `find_one()`
+- `update_one()`, `update_many()`, `replace_one()`
+- `delete_one()`, `delete_many()`
+
+**Query Operators:**
+- `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`
+- `$in`, `$nin`
+- `$and`, `$or`, `$not`, `$nor`
+- `$exists`, `$type`
+- `$regex`
+- `$all`, `$size`
+
+**Aggregation:**
+- `$match`, `$project`, `$group`, `$sort`, `$limit`, `$skip`
+- `$lookup` (basic support)
+- `$unwind`
+- `$addToSet`, `$push`, `$sum`, `$avg`, `$max`, `$min`
+
+**Indexes:**
+- `create_index()`
+- Text search (basic support)
+
+### Limitations
+
+mongomock is not a perfect MongoDB replica:
+
+❌ **Not supported or limited:**
+- Some advanced aggregation operators
+- Transactions (no-op implementation)
+- GridFS
+- Change streams
+- Some edge cases in query behavior
+
+⚠️ **Important:** If you need exact MongoDB behavior, use a real test database
+
+### Testing Text Search
+
+```python
+# mongomock supports basic text search
+collection.create_index([("name", "text"), ("oracle_text", "text")])
+
+# Search works
+results = collection.find({"$text": {"$search": "lightning damage"}})
+
+# Note: Text search scoring may differ from real MongoDB
+```
+
+---
+
+## Custom Mock Implementation
+
+For simple tests or when mongomock doesn't support a feature, you can create custom mocks.
+
+### Using unittest.mock
+
+```python
+from unittest.mock import MagicMock, patch
+
+def test_with_custom_mock():
+    """Test using custom mock collection."""
+
+    # Create mock collection
+    mock_collection = MagicMock()
+
+    # Configure return values
+    mock_collection.find_one.return_value = {
+        "id": "test-id",
+        "name": "Lightning Bolt"
+    }
+
+    mock_collection.find.return_value = [
+        {"name": "Card 1"},
+        {"name": "Card 2"}
+    ]
+
+    # Mock aggregation
+    mock_collection.aggregate.return_value = [
+        {"_id": "oracle-1", "name": "Lightning Bolt", "score": 10.5}
+    ]
+
+    # Use with patch
+    with patch("api.router.cards.collection", mock_collection):
+        # Run your test
+        result = get_card_by_id("test-id")
+        assert result["name"] == "Lightning Bolt"
+
+    # Verify mock was called correctly
+    mock_collection.find_one.assert_called_once_with({"id": "test-id"})
+```
+
+### Custom Mock Classes
+
+For more realism, create custom mock classes:
+
+```python
+class MockMongoCollection:
+    """Custom mock MongoDB collection."""
+
+    def __init__(self, documents=None):
+        self._documents = documents or []
+
+    def find_one(self, query, projection=None):
+        """Simple find_one implementation."""
+        for doc in self._documents:
+            if self._matches_query(doc, query):
+                return self._apply_projection(doc, projection)
+        return None
+
+    def find(self, query, projection=None):
+        """Simple find implementation."""
+        results = []
+        for doc in self._documents:
+            if self._matches_query(doc, query):
+                results.append(self._apply_projection(doc, projection))
+        return MockMongoCursor(results)
+
+    def _matches_query(self, doc, query):
+        """Simple query matching (extend as needed)."""
+        for key, value in query.items():
+            if key not in doc or doc[key] != value:
+                return False
+        return True
+
+    def _apply_projection(self, doc, projection):
+        """Apply field projection."""
+        if not projection:
+            return doc
+        # Implementation here
+        return doc
+
+class MockMongoCursor:
+    """Mock MongoDB cursor."""
+
+    def __init__(self, documents):
+        self._documents = documents
+
+    def sort(self, field, direction=1):
+        """Sort documents."""
+        # Sort implementation
+        return self._documents
+
+    def limit(self, count):
+        """Limit results."""
+        return self._documents[:count]
+```
+
+---
+
+## FastAPI Dependency Injection
+
+### Pattern 1: Collection-Level Injection
+
+```python
+# api/dependencies/database.py
+from fastapi import Depends
+from pymongo import MongoClient
+
+def get_cards_collection():
+    client = MongoClient("mongodb://...")
+    db = client["mtg_db"]
+    return db["cards"]
+
+# api/router/cards.py
+from fastapi import Depends
+from api.dependencies.database import get_cards_collection
+
+@router.get("/cards/id/{card_id}")
+def get_card(card_id: str, collection = Depends(get_cards_collection)):
+    return collection.find_one({"id": card_id})
+
+# tests/test_cards.py
+def test_get_card(mock_collection):
+    app.dependency_overrides[get_cards_collection] = lambda: mock_collection
+
+    client = TestClient(app)
+    response = client.get("/cards/id/test-id")
+
+    app.dependency_overrides.clear()
+```
+
+### Pattern 2: Client-Level Injection
+
+```python
+# api/dependencies/database.py
+def get_mongo_client():
+    return MongoClient("mongodb://...")
+
+def get_database(client = Depends(get_mongo_client)):
+    return client["mtg_db"]
+
+# tests/test_cards.py
+def test_with_mock_client():
+    mock_client = mongomock.MongoClient()
+
+    app.dependency_overrides[get_mongo_client] = lambda: mock_client
+    # All routes will now use mongomock
+```
+
+### Pattern 3: Fixture-Based Override
+
+```python
+# tests/conftest.py
+@pytest.fixture
+def client_with_mock_db():
+    """Automatically override dependencies."""
+    mock_collection = mongomock.MongoClient()["test"]["cards"]
+
+    app.dependency_overrides[get_cards_collection] = lambda: mock_collection
+
+    yield TestClient(app)
+
+    app.dependency_overrides.clear()
+
+# tests/test_cards.py
+def test_example(client_with_mock_db):
+    # Dependencies already overridden
+    response = client_with_mock_db.get("/cards/id/test")
+```
+
+---
+
+## Testing Patterns
+
+### Pattern 1: Arrange-Act-Assert with Fixtures
+
+```python
+def test_search_with_filters(client_with_mock_db, populated_db):
+    # Arrange - data is already in populated_db fixture
+
+    # Act
+    response = client_with_mock_db.post(
+        "/cards/search/instant",
+        json={"colors": ["R"], "cmc_min": 1, "cmc_max": 3}
+    )
+
+    # Assert
+    assert response.status_code == 200
+    cards = response.json()["cards"]
+    assert all(card["cmc"] >= 1 and card["cmc"] <= 3 for card in cards)
+    assert all("R" in card["colors"] for card in cards)
+```
+
+### Pattern 2: Test Data Builders
+
+```python
+class CardBuilder:
+    """Builder pattern for creating test cards."""
+
+    def __init__(self):
+        self.data = {
+            "id": "test-id",
+            "name": "Test Card",
+            "cmc": 3,
+            "colors": [],
+            "type_line": "Creature"
+        }
+
+    def with_id(self, card_id):
+        self.data["id"] = card_id
+        return self
+
+    def with_name(self, name):
+        self.data["name"] = name
+        return self
+
+    def with_cmc(self, cmc):
+        self.data["cmc"] = cmc
+        return self
+
+    def with_colors(self, colors):
+        self.data["colors"] = colors
+        return self
+
+    def build(self):
+        return self.data
+
+# Usage in tests
+def test_with_builder(mock_collection):
+    bolt = CardBuilder().with_name("Lightning Bolt").with_cmc(1).with_colors(["R"]).build()
+    mock_collection.insert_one(bolt)
+
+    result = mock_collection.find_one({"name": "Lightning Bolt"})
+    assert result["cmc"] == 1
+```
+
+### Pattern 3: Parametrized Tests
+
+```python
+@pytest.mark.parametrize("color,expected_count", [
+    (["R"], 5),
+    (["U"], 3),
+    (["W", "U"], 2),
+])
+def test_color_filtering(client_with_mock_db, populated_db, color, expected_count):
+    response = client_with_mock_db.post(
+        "/cards/search/card",
+        json={"colors": color, "color_operator": "or"}
+    )
+
+    assert response.status_code == 200
+    assert len(response.json()["cards"]) == expected_count
+```
+
+---
+
+## Best Practices
+
+### 1. Use Fixtures for Reusable Setup
+
+✅ **Good:**
+```python
+@pytest.fixture
+def sample_cards():
+    return [...]
+
+def test_1(sample_cards):
+    # Use fixture
+
+def test_2(sample_cards):
+    # Reuse fixture
+```
+
+❌ **Bad:**
+```python
+def test_1():
+    cards = [...]  # Duplicate setup
+
+def test_2():
+    cards = [...]  # Duplicate setup
+```
+
+### 2. Clean Up After Tests
+
+✅ **Good:**
+```python
+@pytest.fixture
+def client_with_mock_db():
+    # Setup
+    app.dependency_overrides[get_db] = lambda: mock_db
+    yield TestClient(app)
+    # Teardown
+    app.dependency_overrides.clear()
+```
+
+❌ **Bad:**
+```python
+def test_something():
+    app.dependency_overrides[get_db] = lambda: mock_db
+    # No cleanup - affects other tests!
+```
+
+### 3. Test Isolation
+
+✅ **Good:**
+```python
+@pytest.fixture(scope="function")  # New instance per test
+def mock_db():
+    return mongomock.MongoClient()["test"]["cards"]
+```
+
+❌ **Bad:**
+```python
+@pytest.fixture(scope="session")  # Shared across tests
+def mock_db():
+    return mongomock.MongoClient()["test"]["cards"]
+    # Tests can pollute each other's data!
+```
+
+### 4. Realistic Test Data
+
+✅ **Good:**
+```python
+{
+    "id": "bd8fa327-dd41-4737-8f19-2cf5eb1f7cdd",  # Real UUID format
+    "oracle_id": "e3285e6b-3e79-4d7c-bf96-d920f973b122",
+    "name": "Lightning Bolt",
+    "mana_cost": "{R}",
+    "cmc": 1,
+    # All required fields present
+}
+```
+
+❌ **Bad:**
+```python
+{
+    "id": "123",  # Unrealistic
+    "name": "Test Card"
+    # Missing fields
+}
+```
+
+### 5. Test Both Success and Failure
+
+```python
+def test_get_card_success(client_with_mock_db, populated_db):
+    response = client_with_mock_db.get("/cards/id/test-id")
+    assert response.status_code == 200
+
+def test_get_card_not_found(client_with_mock_db, populated_db):
+    response = client_with_mock_db.get("/cards/id/nonexistent")
+    assert response.status_code == 404
+```
+
+### 6. Use Descriptive Test Names
+
+✅ **Good:**
+```python
+def test_search_returns_cards_matching_color_filter_with_or_operator():
+    ...
+
+def test_search_returns_404_when_no_cards_match_filter():
+    ...
+```
+
+❌ **Bad:**
+```python
+def test_search():
+    ...
+
+def test_colors():
+    ...
+```
+
+### 7. Don't Test MongoDB Itself
+
+✅ **Good:**
+```python
+def test_get_card_by_id_returns_correct_card():
+    # Test your API logic
+    response = client.get("/cards/id/test-id")
+    assert response.json()["name"] == "Lightning Bolt"
+```
+
+❌ **Bad:**
+```python
+def test_mongodb_find_one_works():
+    # Don't test PyMongo/MongoDB
+    result = collection.find_one({"id": "test"})
+    assert result is not None
+```
+
+---
+
+## Troubleshooting
+
+### Issue: Tests pass with mock but fail in production
+
+**Cause:** Mock behavior differs from real MongoDB
+
+**Solution:**
+- Use mongomock instead of custom mocks for more realistic behavior
+- Add E2E tests with real MongoDB for critical paths
+- Verify query syntax matches MongoDB documentation
+
+### Issue: Dependency overrides not working
+
+**Cause:** Wrong dependency being overridden or not cleared
+
+**Solution:**
+```python
+# Make sure you override the exact dependency used in routes
+app.dependency_overrides[get_cards_collection] = lambda: mock_collection
+
+# Always clear after tests
+app.dependency_overrides.clear()
+```
+
+### Issue: mongomock doesn't support a feature
+
+**Cause:** mongomock has limited support for some advanced MongoDB features
+
+**Solution:**
+- Check mongomock documentation for supported features
+- Use custom mock for unsupported features
+- Use real test database for complex queries
+
+### Issue: Tests are slow
+
+**Cause:** Creating new MongoDB connections for each test
+
+**Solution:**
+```python
+# Use function scope for isolation, but reuse client
+@pytest.fixture(scope="session")
+def mock_client():
+    return mongomock.MongoClient()
+
+@pytest.fixture
+def mock_collection(mock_client):
+    db = mock_client["test"]
+    collection = db["cards"]
+    yield collection
+    collection.drop()  # Clean up
+```
+
+### Issue: Text search not working in mongomock
+
+**Cause:** mongomock text search is limited
+
+**Solution:**
+```python
+# Create text index first
+collection.create_index([("name", "text")])
+
+# Use basic text search
+collection.find({"$text": {"$search": "lightning"}})
+
+# For complex text search, use real database or custom mock
+```
+
+---
+
+## Summary
+
+### Quick Decision Guide
+
+**Use mongomock when:**
+- ✅ Writing integration tests for FastAPI endpoints
+- ✅ Testing MongoDB queries and aggregations
+- ✅ Need realistic database behavior without external dependencies
+- ✅ CI/CD pipeline needs database testing
+
+**Use unittest.mock when:**
+- ✅ Writing unit tests for pure business logic
+- ✅ Testing error handling and edge cases
+- ✅ Need to verify specific function calls
+- ✅ Mocking is trivial (simple return values)
+
+**Use real test database when:**
+- ✅ Running E2E tests
+- ✅ Testing complex queries mongomock doesn't support
+- ✅ Validating production-like behavior
+- ✅ Performance testing
+
+### Recommended Setup for This Project
+
+```python
+# tests/conftest.py
+import pytest
+import mongomock
+from fastapi.testclient import TestClient
+from api.main import app
+from api.dependencies.database import get_cards_collection
+
+@pytest.fixture
+def mock_collection():
+    """mongomock collection for integration tests."""
+    client = mongomock.MongoClient()
+    return client["test"]["cards"]
+
+@pytest.fixture
+def client_with_mock_db(mock_collection):
+    """TestClient with mongomock."""
+    app.dependency_overrides[get_cards_collection] = lambda: mock_collection
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+@pytest.fixture
+def sample_cards():
+    """Realistic test card data."""
+    return [
+        # Lightning Bolt, Counterspell, etc.
+    ]
+
+@pytest.fixture
+def populated_db(mock_collection, sample_cards):
+    """Pre-populated test database."""
+    mock_collection.insert_many(sample_cards)
+    mock_collection.create_index([("name", "text")])
+    return mock_collection
+```
+
+---
+
+## References
+
+- [mongomock GitHub Repository](https://github.com/mongomock/mongomock)
+- [FastAPI Testing Documentation](https://fastapi.tiangolo.com/tutorial/testing/)
+- [FastAPI Dependency Injection](https://fastapi.tiangolo.com/tutorial/dependencies/)
+- [pytest Fixtures](https://docs.pytest.org/en/stable/fixture.html)
+- [Python unittest.mock](https://docs.python.org/3/library/unittest.mock.html)
+- [PyMongo Documentation](https://pymongo.readthedocs.io/)

--- a/documentation/phase-5-search-endpoint-tests-plan.md
+++ b/documentation/phase-5-search-endpoint-tests-plan.md
@@ -1,0 +1,1547 @@
+# Phase 5: Cards Router Integration Tests - Search Endpoint
+
+**Date**: 2025-11-16
+**Phase**: 5 of 9
+**Complexity**: High
+**Estimated Effort**: 3-4 hours
+**Dependencies**: Phase 1 (Test Infrastructure) must be complete
+
+---
+
+## Overview
+
+Phase 5 implements comprehensive integration tests for the `/cards/search/{text}` endpoint, the most complex endpoint in the MTG API. This endpoint combines full-text search with multi-dimensional filtering (colors, CMC, types, rarities, sets), cursor-based pagination, and MongoDB aggregation pipelines.
+
+**Why this phase is critical:**
+- The search endpoint is the core feature of the MTG card API
+- It has the most complex query logic with multiple filter combinations (2^6 = 64 possible combinations)
+- Pagination logic using score-based cursors is non-trivial and error-prone
+- The endpoint constructs dynamic MongoDB aggregation pipelines based on user filters
+- Edge cases (colorless, five-color, CMC 0) require careful testing
+
+---
+
+## Current Implementation Analysis
+
+### Endpoint Signature
+```python
+@router.get("/cards/search/{text}")
+def search_card_by_text(
+    text: str,
+    collection: CardsCollection,
+    lang: str = "en",
+    cursor: Optional[str] = None,
+    page_count=10,
+    card_filter: Optional[CardFilter] = None,
+)
+```
+
+### CardFilter Model
+```python
+class CardFilter(BaseModel):
+    sets: Optional[list[str]] = None              # Filter by set names
+    colors: Optional[list[str]] = None            # WUBRG filter
+    color_operator: Optional[str] = "or"          # "or", "and", "exactly"
+    cmc_min: Optional[int] = None                 # Minimum CMC
+    cmc_max: Optional[int] = None                 # Maximum CMC
+    types: Optional[list[str]] = None             # creature, instant, sorcery
+    rarities: Optional[list[str]] = None          # common, uncommon, rare, mythic
+```
+
+### Aggregation Pipeline Flow
+
+The endpoint builds a MongoDB aggregation pipeline with these stages:
+
+1. **$match** - Text search + filters (sets, colors, CMC, types, rarities)
+2. **$project** - Add text search score + card fields
+3. **$group** - Aggregate by oracle_id (same card, different printings)
+4. **$sort** - Sort by text search score (descending)
+5. **$match** - Apply cursor pagination (score < cursor_value)
+6. **$limit** - Return page_count + 1 (to determine has_more)
+
+### Response Structure
+```python
+{
+    "cards": [...],            # Array of card objects (max: page_count)
+    "cursor": "0.85",          # Score of second-to-last card (for next page)
+    "has_more": true           # True if len(results) > page_count
+}
+```
+
+### Filter Logic Complexity
+
+**Color Operator Variations:**
+- `"or"` → `{"colors": {"$in": ["R", "G"]}}` - Contains ANY of these colors
+- `"and"` → `{"colors": {"$all": ["R", "G"]}}` - Contains ALL of these colors
+- `"exactly"` → `{"colors": {"$all": ["R", "G"], "$size": 2}}` - EXACTLY these colors
+
+**CMC Range Variations:**
+- `cmc_min` only → `{"cmc": {"$gte": 3}}`
+- `cmc_max` only → `{"cmc": {"$lte": 5}}`
+- Both → `{"cmc": {"$gte": 3, "$lte": 5}}`
+
+**Type Matching:**
+- Uses `$or` with regex patterns: `[{"type_line": {"$regex": "creature", "$options": "i"}}]`
+
+---
+
+## Mock MongoDB Enhancement Requirements
+
+### Current MockMongoCollection Support
+
+✅ **Already Supported:**
+- `$match` stage
+- `$project` stage
+- `$group` stage (with $first, $sum, $max, $addToSet)
+- `$sort` stage
+- `$limit` stage
+- `$text` operator (basic text search)
+- `$in`, `$all`, `$gte`, `$lte` operators
+- `$or`, `$and` logical operators
+
+❌ **NOT Yet Supported:**
+- `$size` operator for exact color matching (`color_operator="exactly"`)
+- Text search score simulation (`{"$project": {"score": 1}}`)
+
+### Required Enhancements
+
+**1. Add `$size` operator support** (`tests/mocks/mongodb.py`)
+
+Location: `MockMongoCollection._matches_query()` method
+
+```python
+elif operator == "$size":
+    if not isinstance(field_value, list):
+        return False
+    if len(field_value) != value:
+        return False
+```
+
+**2. Add text search score simulation** (`tests/mocks/mongodb.py`)
+
+Location: `MockMongoCollection._execute_aggregation_stage()` method for `$project`
+
+```python
+# In $project stage execution
+if stage_spec.get("score") == 1:
+    # Add mock text search score (higher = better match)
+    # Simulate scores: 1.0 for perfect match, 0.5-0.9 for partial matches
+    for doc in documents:
+        if "score" not in doc:
+            doc["score"] = self._calculate_mock_score(doc, search_text)
+```
+
+**Why we need score simulation:**
+- Pagination relies on score-based cursors (`cursor: "0.85"`)
+- Tests must verify cursor pagination works correctly
+- We need deterministic scores for reproducible tests
+
+**Score Simulation Strategy:**
+```python
+def _calculate_mock_score(self, doc: dict, search_text: str) -> float:
+    """Calculate mock text search score for testing.
+
+    Returns:
+        Score between 0.0 and 1.0 (higher = better match)
+    """
+    name = doc.get("name", "").lower()
+    oracle_text = doc.get("oracle_text", "").lower()
+    search = search_text.lower()
+
+    # Perfect name match = 1.0
+    if search == name:
+        return 1.0
+
+    # Name starts with search = 0.9
+    if name.startswith(search):
+        return 0.9
+
+    # Search in name = 0.8
+    if search in name:
+        return 0.8
+
+    # Search in oracle text = 0.6
+    if search in oracle_text:
+        return 0.6
+
+    # Weak match = 0.3
+    return 0.3
+```
+
+---
+
+## Test Data Requirements
+
+### Additional Sample Cards Needed
+
+The current `tests/fixtures/sample_cards.py` has 7 cards, but we need more variety for comprehensive filter testing.
+
+**Add these cards:**
+
+```python
+# Izzet Charm - Two-color (U/R) instant
+IZZET_CHARM = {
+    "id": "...",
+    "oracle_id": "...",
+    "name": "Izzet Charm",
+    "name_search": "izzet charm",
+    "lang": "en",
+    "released_at": "2012-10-05",
+    "layout": "normal",
+    "cmc": 2.0,
+    "type_line": "Instant",
+    "oracle_text": "Choose one — • Counter target noncreature spell unless its controller pays {2}. • Izzet Charm deals 2 damage to target creature. • Draw two cards, then discard two cards.",
+    "mana_cost": "{U}{R}",
+    "colors": ["U", "R"],
+    "color_identity": ["U", "R"],
+    "rarity": "uncommon",
+    "set_name": "Return to Ravnica",
+    "set": "rtr",
+    "artist": "Zoltan Boros",
+    # ... image_uris
+}
+
+# Giant Growth - Green instant, CMC 1
+GIANT_GROWTH = {
+    "id": "...",
+    "oracle_id": "...",
+    "name": "Giant Growth",
+    "name_search": "giant growth",
+    "lang": "en",
+    "released_at": "1993-08-05",
+    "layout": "normal",
+    "cmc": 1.0,
+    "type_line": "Instant",
+    "oracle_text": "Target creature gets +3/+3 until end of turn.",
+    "mana_cost": "{G}",
+    "colors": ["G"],
+    "color_identity": ["G"],
+    "rarity": "common",
+    "set_name": "Limited Edition Alpha",
+    "set": "lea",
+    # ... image_uris
+}
+
+# Serra Angel - White creature, CMC 5
+SERRA_ANGEL = {
+    "id": "...",
+    "oracle_id": "...",
+    "name": "Serra Angel",
+    "name_search": "serra angel",
+    "lang": "en",
+    "released_at": "1993-08-05",
+    "layout": "normal",
+    "cmc": 5.0,
+    "type_line": "Creature — Angel",
+    "oracle_text": "Flying, vigilance",
+    "mana_cost": "{3}{W}{W}",
+    "colors": ["W"],
+    "color_identity": ["W"],
+    "power": "4",
+    "toughness": "4",
+    "rarity": "uncommon",
+    "set_name": "Limited Edition Alpha",
+    "set": "lea",
+    # ... image_uris
+}
+
+# Doom Blade - Black instant, CMC 2
+DOOM_BLADE = {
+    "id": "...",
+    "oracle_id": "...",
+    "name": "Doom Blade",
+    "name_search": "doom blade",
+    "lang": "en",
+    "released_at": "2010-07-16",
+    "layout": "normal",
+    "cmc": 2.0,
+    "type_line": "Instant",
+    "oracle_text": "Destroy target nonblack creature.",
+    "mana_cost": "{1}{B}",
+    "colors": ["B"],
+    "color_identity": ["B"],
+    "rarity": "common",
+    "set_name": "Magic 2011",
+    "set": "m11",
+    # ... image_uris
+}
+
+# Emrakul, the Aeons Torn - Colorless creature, CMC 15
+EMRAKUL = {
+    "id": "...",
+    "oracle_id": "...",
+    "name": "Emrakul, the Aeons Torn",
+    "name_search": "emrakul, the aeons torn",
+    "lang": "en",
+    "released_at": "2010-04-23",
+    "layout": "normal",
+    "cmc": 15.0,
+    "type_line": "Legendary Creature — Eldrazi",
+    "oracle_text": "Emrakul, the Aeons Torn can't be countered.\nWhen you cast this spell, take an extra turn after this one.\nFlying, protection from colored spells, annihilator 6\nWhen Emrakul is put into a graveyard from anywhere, its owner shuffles their graveyard into their library.",
+    "mana_cost": "{15}",
+    "colors": [],  # Colorless
+    "color_identity": [],
+    "power": "15",
+    "toughness": "15",
+    "rarity": "mythic",
+    "set_name": "Rise of the Eldrazi",
+    "set": "roe",
+    # ... image_uris
+}
+```
+
+**Why these cards:**
+- **Izzet Charm**: Two-color card for "or"/"and" color operator testing
+- **Giant Growth**: Green instant for multi-color filter combinations
+- **Serra Angel**: White creature for type filtering (creature vs instant)
+- **Doom Blade**: Black instant for complete WUBRG color coverage
+- **Emrakul**: High CMC (15) colorless creature for edge case testing
+
+**Updated test data coverage:**
+- **Colors**: All WUBRG covered individually + multi-color cards
+- **CMC Range**: 0, 1, 2, 5, 10, 15 (wide spectrum)
+- **Types**: Instant, Creature, Artifact, Legendary
+- **Rarities**: Common, Uncommon, Rare, Mythic (all covered)
+- **Sets**: Multiple different sets for set filtering
+
+---
+
+## Test File Structure
+
+### File: `tests/api/router/test_cards_search_integration.py`
+
+**Organization:**
+```python
+"""Integration tests for Cards Search endpoint (/cards/search/{text}).
+
+This module tests the most complex endpoint with:
+- Full-text search functionality
+- Cursor-based pagination
+- Multi-dimensional filtering (colors, CMC, types, rarities, sets)
+- MongoDB aggregation pipeline execution
+- Edge cases and filter combinations
+
+Test Categories:
+1. Basic text search (lines 20-50)
+2. Pagination tests (lines 52-150)
+3. Filter tests - Individual (lines 152-400)
+4. Filter tests - Combinations (lines 402-500)
+5. Edge cases (lines 502-600)
+"""
+
+import pytest
+from tests.fixtures.sample_cards import (
+    LIGHTNING_BOLT,
+    COUNTERSPELL,
+    BLACK_LOTUS,
+    PROGENITUS,
+    DELVER_OF_SECRETS,
+    SOL_RING,
+    # New cards
+    IZZET_CHARM,
+    GIANT_GROWTH,
+    SERRA_ANGEL,
+    DOOM_BLADE,
+    EMRAKUL,
+)
+
+
+# Test organization:
+# - Mark all tests with @pytest.mark.integration
+# - Group related tests together
+# - Use descriptive docstrings with "Why" and "Expected"
+# - Follow existing test pattern from test_cards_basic_integration.py
+```
+
+---
+
+## Implementation Tasks (Detailed)
+
+### Task 1: Enhance Mock MongoDB with $size Operator
+
+**File**: `tests/mocks/mongodb.py`
+**Lines**: 179-197 (in `_matches_query` method)
+
+**What to update:**
+Add `$size` operator support after the `$all` operator case:
+
+```python
+elif operator == "$all":
+    if not isinstance(field_value, list):
+        return False
+    if not all(item in field_value for item in value):
+        return False
+elif operator == "$size":  # NEW
+    if not isinstance(field_value, list):
+        return False
+    if len(field_value) != value:
+        return False
+```
+
+**Why:**
+- The `color_operator="exactly"` filter uses `{"colors": {"$all": [...], "$size": n}}`
+- Without `$size` support, tests for exact color matching will fail
+- This is a MongoDB standard operator that should be supported
+
+**Test this change:**
+```python
+# In tests/mocks/test_mongodb.py
+def test_size_operator():
+    """Test that $size operator filters arrays by exact length."""
+    collection = MockMongoCollection([
+        {"colors": ["R", "G"]},
+        {"colors": ["R"]},
+        {"colors": []},
+    ])
+
+    results = list(collection.find({"colors": {"$size": 2}}))
+    assert len(results) == 1
+    assert results[0]["colors"] == ["R", "G"]
+```
+
+---
+
+### Task 2: Enhance Mock MongoDB with Text Search Score
+
+**File**: `tests/mocks/mongodb.py`
+**Location**: Add new method + modify `_execute_aggregation_stage`
+
+**What to update:**
+
+1. **Add score calculation method** (after `_execute_group_stage`):
+
+```python
+def _calculate_text_score(self, doc: dict, search_text: str) -> float:
+    """Calculate mock text search score for pagination testing.
+
+    Simulates MongoDB $text search score based on text relevance.
+    Higher scores indicate better matches.
+
+    Args:
+        doc: Document to score
+        search_text: Search query text
+
+    Returns:
+        Score between 0.0 and 1.0
+    """
+    if not search_text:
+        return 0.5  # Default score
+
+    name = doc.get("name", "").lower()
+    oracle_text = doc.get("oracle_text", "").lower()
+    search = search_text.lower()
+
+    # Scoring rules (deterministic for testing):
+    if search == name:
+        return 1.0  # Perfect match
+    elif name.startswith(search):
+        return 0.9  # Prefix match
+    elif search in name:
+        return 0.8  # Substring match in name
+    elif search in oracle_text:
+        return 0.6  # Match in card text
+    else:
+        return 0.3  # Weak/generic match
+```
+
+2. **Store search text in collection** (add to `__init__`):
+
+```python
+def __init__(self, documents: list[dict]):
+    """Initialize collection with documents."""
+    self._documents = deepcopy(documents)
+    self._last_search_text = None  # NEW: Track last text search
+```
+
+3. **Capture search text during $match** (in `_matches_query`):
+
+```python
+elif field == "$text":
+    # Text search - simple implementation
+    search_text = condition.get("$search", "").lower()
+    self._last_search_text = search_text  # NEW: Save for scoring
+    doc_text = str(doc).lower()
+    if search_text not in doc_text:
+        return False
+```
+
+4. **Add score to $project stage** (in `_execute_aggregation_stage`):
+
+```python
+elif stage_type == "$project":
+    # Project fields
+    projected = []
+    for doc in documents:
+        projected_doc = self._apply_projection(doc, stage_spec)
+
+        # NEW: Add text search score if requested
+        if stage_spec.get("score") == 1 and self._last_search_text:
+            projected_doc["score"] = self._calculate_text_score(
+                doc, self._last_search_text
+            )
+
+        projected.append(projected_doc)
+    return projected
+```
+
+5. **Update $group to handle score field**:
+
+```python
+# In _execute_group_stage, add after $addToSet case:
+elif acc_type == "$max":
+    field_name = (
+        acc_value[1:] if acc_value.startswith("$") else acc_value
+    )
+    current_value = doc.get(field_name)
+    if current_value is not None:
+        if (
+            field not in groups[key]
+            or current_value > groups[key][field]
+        ):
+            groups[key][field] = current_value
+```
+
+**Why:**
+- Cursor-based pagination uses `score < cursor_value` for "next page" queries
+- Without score simulation, we cannot test pagination logic
+- Deterministic scoring ensures reproducible tests
+
+**Test this change:**
+```python
+# In tests/mocks/test_mongodb.py
+def test_text_search_score_in_aggregation():
+    """Test that text search score is added to projection."""
+    collection = MockMongoCollection([
+        {"name": "Lightning Bolt", "oracle_text": "deals 3 damage"},
+        {"name": "Counterspell", "oracle_text": "counter target spell"},
+    ])
+
+    pipeline = [
+        {"$match": {"$text": {"$search": "lightning"}}},
+        {"$project": {"score": 1, "name": 1}},
+    ]
+
+    results = list(collection.aggregate(pipeline))
+    assert len(results) > 0
+    assert "score" in results[0]
+    assert results[0]["score"] > 0.0
+```
+
+---
+
+### Task 3: Add New Sample Cards to Fixtures
+
+**File**: `tests/fixtures/sample_cards.py`
+**Lines**: After SOL_RING definition (line 247)
+
+**What to add:**
+Add 5 new card definitions (see "Test Data Requirements" section above):
+1. IZZET_CHARM
+2. GIANT_GROWTH
+3. SERRA_ANGEL
+4. DOOM_BLADE
+5. EMRAKUL
+
+**Update `get_all_sample_cards()`:**
+```python
+def get_all_sample_cards() -> list[dict]:
+    """Get all sample cards as a list."""
+    return [
+        LIGHTNING_BOLT,
+        LIGHTNING_BOLT_REPRINT,
+        COUNTERSPELL,
+        BLACK_LOTUS,
+        PROGENITUS,
+        DELVER_OF_SECRETS,
+        SOL_RING,
+        IZZET_CHARM,        # NEW
+        GIANT_GROWTH,       # NEW
+        SERRA_ANGEL,        # NEW
+        DOOM_BLADE,         # NEW
+        EMRAKUL,            # NEW
+    ]
+```
+
+**Why:**
+- Need complete WUBRG color coverage for filter tests
+- Need variety of CMC values (0, 1, 2, 5, 10, 15)
+- Need mix of creatures and instants for type filtering
+- Need multiple sets for set filter testing
+
+**Test this change:**
+Run existing fixture tests to ensure no regressions:
+```bash
+pytest tests/fixtures/test_sample_cards.py -v
+```
+
+---
+
+### Task 4-7: Basic Text Search Tests
+
+**File**: `tests/api/router/test_cards_search_integration.py` (NEW)
+**Lines**: 1-150
+
+**Test 4.1: Basic text search without filters**
+
+```python
+@pytest.mark.integration
+def test_search_basic_text_query(test_client):
+    """Test /cards/search/{text} with basic text query (no filters).
+
+    This validates:
+    - Endpoint returns HTTP 200
+    - MongoDB $text search is executed
+    - Results are aggregated by oracle_id
+    - Response structure matches expected format
+    - Text search matches card name and oracle_text
+
+    Search: "lightning"
+    Expected: Lightning Bolt (matches name)
+    """
+    response = test_client.get("/cards/search/lightning")
+
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "cards" in data
+    assert "cursor" in data
+    assert "has_more" in data
+
+    # Should find Lightning Bolt
+    assert len(data["cards"]) > 0
+    card_names = [card["name"] for card in data["cards"]]
+    assert "Lightning Bolt" in card_names
+
+
+@pytest.mark.integration
+def test_search_matches_oracle_text(test_client):
+    """Test that text search matches oracle_text field.
+
+    This validates:
+    - $text search includes oracle_text (not just name)
+    - Cards with matching oracle_text are returned
+
+    Search: "damage"
+    Expected: Lightning Bolt ("deals 3 damage")
+    """
+    response = test_client.get("/cards/search/damage")
+
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data["cards"]) > 0
+
+    # Lightning Bolt has "deals 3 damage" in oracle_text
+    card_names = [card["name"] for card in data["cards"]]
+    assert "Lightning Bolt" in card_names
+```
+
+**Test 4.2: Empty results**
+
+```python
+@pytest.mark.integration
+def test_search_no_results(test_client):
+    """Test search with no matching results.
+
+    This validates:
+    - Empty results return valid response structure
+    - cards array is empty
+    - cursor is None
+    - has_more is False
+
+    Search: "nonexistentcardxyz"
+    Expected: Empty results
+    """
+    response = test_client.get("/cards/search/nonexistentcardxyz")
+
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["cards"] == []
+    assert data["cursor"] is None
+    assert data["has_more"] is False
+```
+
+**Why these tests:**
+- Validate basic endpoint functionality works
+- Ensure response structure is correct
+- Test both success and empty result cases
+
+---
+
+### Task 8-11: Pagination Tests
+
+**Lines**: 152-280
+
+**Test 8.1: Default page size (10)**
+
+```python
+@pytest.mark.integration
+def test_search_default_page_count(test_client):
+    """Test that default page_count is 10.
+
+    This validates:
+    - When page_count not specified, returns max 10 cards
+    - Even if more results exist, only 10 returned
+    - has_more flag indicates more results available
+
+    Note: With 12 sample cards, should return 10 with has_more=True
+    """
+    response = test_client.get("/cards/search/a")  # Very broad search
+
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data["cards"]) <= 10  # Default page size
+```
+
+**Test 8.2: Custom page_count parameter**
+
+```python
+@pytest.mark.integration
+def test_search_custom_page_count_5(test_client):
+    """Test search with page_count=5.
+
+    This validates:
+    - page_count parameter controls result count
+    - Returns max 5 cards when page_count=5
+
+    Search: "a" (broad search)
+    Page count: 5
+    Expected: 5 cards max
+    """
+    response = test_client.get("/cards/search/a?page_count=5")
+
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data["cards"]) <= 5
+
+
+@pytest.mark.integration
+def test_search_custom_page_count_20(test_client):
+    """Test search with page_count=20.
+
+    This validates:
+    - Large page_count values work correctly
+    - With 12 sample cards, returns all cards (no pagination)
+
+    Search: "a" (broad search)
+    Page count: 20
+    Expected: All matching cards (< 20)
+    """
+    response = test_client.get("/cards/search/a?page_count=20")
+
+    assert response.status_code == 200
+
+    data = response.json()
+    # Should return all matching cards since page_count > total cards
+    assert data["has_more"] is False
+```
+
+**Test 8.3: Cursor-based pagination**
+
+```python
+@pytest.mark.integration
+def test_search_cursor_pagination(test_client):
+    """Test cursor-based pagination for next page.
+
+    This validates:
+    - First request returns cursor value
+    - Second request with cursor returns next page
+    - Cursor is based on text search score
+    - No duplicate cards between pages
+
+    Flow:
+    1. Get first page (page_count=3)
+    2. Use cursor from first page to get second page
+    3. Verify no overlap between pages
+    """
+    # First page
+    response1 = test_client.get("/cards/search/a?page_count=3")
+    data1 = response1.json()
+
+    assert len(data1["cards"]) == 3
+    assert data1["cursor"] is not None  # Has next page
+
+    # Second page using cursor
+    cursor = data1["cursor"]
+    response2 = test_client.get(f"/cards/search/a?page_count=3&cursor={cursor}")
+    data2 = response2.json()
+
+    # Verify no overlap
+    page1_ids = {card["_id"] for card in data1["cards"]}
+    page2_ids = {card["_id"] for card in data2["cards"]}
+    assert page1_ids.isdisjoint(page2_ids)  # No duplicates
+
+
+@pytest.mark.integration
+def test_search_has_more_flag_true(test_client):
+    """Test has_more flag is True when more results exist.
+
+    This validates:
+    - has_more=True when results exceed page_count
+    - Fetches page_count+1 results internally
+    - Only returns page_count results to client
+
+    Search: "a" (broad search for many results)
+    Page count: 2
+    Expected: has_more=True (12 sample cards > 2)
+    """
+    response = test_client.get("/cards/search/a?page_count=2")
+
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data["cards"]) == 2
+    assert data["has_more"] is True
+    assert data["cursor"] is not None
+
+
+@pytest.mark.integration
+def test_search_has_more_flag_false(test_client):
+    """Test has_more flag is False at end of results.
+
+    This validates:
+    - has_more=False when no more results exist
+    - cursor=None when on last page
+
+    Search: Very specific search with 1-2 results
+    Page count: 10 (larger than result count)
+    Expected: has_more=False, cursor=None
+    """
+    response = test_client.get("/cards/search/emrakul?page_count=10")
+
+    assert response.status_code == 200
+
+    data = response.json()
+    # Only 1 Emrakul card exists
+    assert data["has_more"] is False
+    assert data["cursor"] is None
+```
+
+**Why these tests:**
+- Pagination is complex and error-prone
+- Cursor logic must be verified thoroughly
+- has_more flag is critical for UI "load more" buttons
+- Edge cases (first page, last page, exact page boundary)
+
+---
+
+### Task 12-18: Filter Tests - Individual Filters
+
+**Lines**: 282-500
+
+**Test 12.1: Sets filter (single set)**
+
+```python
+@pytest.mark.integration
+def test_search_filter_single_set(test_client):
+    """Test search with sets filter (single set).
+
+    This validates:
+    - CardFilter.sets parameter filters by set_name
+    - MongoDB $in operator works correctly
+    - Only cards from specified set are returned
+
+    Search: "bolt"
+    Filter: sets=["Limited Edition Alpha"]
+    Expected: Lightning Bolt from LEA (not Double Masters reprint)
+    """
+    response = test_client.get(
+        "/cards/search/bolt",
+        params={"card_filter": {"sets": ["Limited Edition Alpha"]}}
+    )
+
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data["cards"]) > 0
+
+    # All cards should be from Limited Edition Alpha
+    for card in data["cards"]:
+        # Note: Aggregation groups by oracle_id, so check cards array
+        assert all(c["set_name"] == "Limited Edition Alpha"
+                   for c in card["cards"])
+
+
+@pytest.mark.integration
+def test_search_filter_multiple_sets(test_client):
+    """Test search with sets filter (multiple sets).
+
+    This validates:
+    - Multiple set names in sets array work correctly
+    - $in operator with multiple values
+
+    Search: "bolt"
+    Filter: sets=["Limited Edition Alpha", "Double Masters"]
+    Expected: Both Lightning Bolt printings
+    """
+    response = test_client.get(
+        "/cards/search/bolt",
+        params={
+            "card_filter": {
+                "sets": ["Limited Edition Alpha", "Double Masters"]
+            }
+        }
+    )
+
+    assert response.status_code == 200
+
+    data = response.json()
+    # Should find Lightning Bolt with printings from both sets
+    assert len(data["cards"]) > 0
+```
+
+**Test 12.2: Colors filter with "or" operator**
+
+```python
+@pytest.mark.integration
+def test_search_filter_colors_or_operator(test_client):
+    """Test search with colors filter using 'or' operator.
+
+    This validates:
+    - CardFilter.colors with color_operator="or" (default)
+    - MongoDB $in operator for colors field
+    - Returns cards with ANY of the specified colors
+
+    Search: "a" (broad search)
+    Filter: colors=["R", "U"], operator="or"
+    Expected: Lightning Bolt (R), Counterspell (U), Izzet Charm (U+R)
+    """
+    response = test_client.get(
+        "/cards/search/a",
+        params={
+            "card_filter": {
+                "colors": ["R", "U"],
+                "color_operator": "or"
+            }
+        }
+    )
+
+    assert response.status_code == 200
+
+    data = response.json()
+    card_names = [card["name"] for card in data["cards"]]
+
+    # Should include red cards
+    assert "Lightning Bolt" in card_names
+    # Should include blue cards
+    assert "Counterspell" in card_names
+    # Should NOT include green-only cards
+    assert "Giant Growth" not in card_names
+
+
+@pytest.mark.integration
+def test_search_filter_colors_and_operator(test_client):
+    """Test search with colors filter using 'and' operator.
+
+    This validates:
+    - CardFilter.colors with color_operator="and"
+    - MongoDB $all operator for colors field
+    - Returns only cards containing ALL specified colors
+
+    Search: "a" (broad search)
+    Filter: colors=["U", "R"], operator="and"
+    Expected: Only Izzet Charm (has both U and R)
+    """
+    response = test_client.get(
+        "/cards/search/a",
+        params={
+            "card_filter": {
+                "colors": ["U", "R"],
+                "color_operator": "and"
+            }
+        }
+    )
+
+    assert response.status_code == 200
+
+    data = response.json()
+    card_names = [card["name"] for card in data["cards"]]
+
+    # Should include cards with BOTH U and R
+    assert "Izzet Charm" in card_names
+
+    # Should NOT include cards with only R
+    assert "Lightning Bolt" not in card_names
+    # Should NOT include cards with only U
+    assert "Counterspell" not in card_names
+
+
+@pytest.mark.integration
+def test_search_filter_colors_exactly_operator(test_client):
+    """Test search with colors filter using 'exactly' operator.
+
+    This validates:
+    - CardFilter.colors with color_operator="exactly"
+    - MongoDB $all + $size operators for exact color match
+    - Returns only cards with EXACTLY these colors (no more, no less)
+
+    Search: "a" (broad search)
+    Filter: colors=["U", "R"], operator="exactly"
+    Expected: Only Izzet Charm (exactly U+R, not Progenitus with WUBRG)
+    """
+    response = test_client.get(
+        "/cards/search/a",
+        params={
+            "card_filter": {
+                "colors": ["U", "R"],
+                "color_operator": "exactly"
+            }
+        }
+    )
+
+    assert response.status_code == 200
+
+    data = response.json()
+    card_names = [card["name"] for card in data["cards"]]
+
+    # Should include Izzet Charm (exactly U+R)
+    assert "Izzet Charm" in card_names
+
+    # Should NOT include mono-colored cards
+    assert "Lightning Bolt" not in card_names
+    assert "Counterspell" not in card_names
+
+    # Should NOT include cards with more than 2 colors
+    assert "Progenitus" not in card_names  # Has all 5 colors
+```
+
+**Test 12.3: CMC filters**
+
+```python
+@pytest.mark.integration
+def test_search_filter_cmc_min_only(test_client):
+    """Test search with cmc_min filter only.
+
+    This validates:
+    - CardFilter.cmc_min parameter
+    - MongoDB $gte operator
+    - Returns cards with CMC >= min value
+
+    Search: "a" (broad search)
+    Filter: cmc_min=5
+    Expected: Serra Angel (5), Progenitus (10), Emrakul (15)
+    NOT: Lightning Bolt (1), Counterspell (2)
+    """
+    response = test_client.get(
+        "/cards/search/a",
+        params={"card_filter": {"cmc_min": 5}}
+    )
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    # All cards should have CMC >= 5
+    for card in data["cards"]:
+        assert card["cmc"] >= 5
+
+
+@pytest.mark.integration
+def test_search_filter_cmc_max_only(test_client):
+    """Test search with cmc_max filter only.
+
+    This validates:
+    - CardFilter.cmc_max parameter
+    - MongoDB $lte operator
+    - Returns cards with CMC <= max value
+
+    Search: "a" (broad search)
+    Filter: cmc_max=2
+    Expected: Black Lotus (0), Lightning Bolt (1), Counterspell (2)
+    NOT: Serra Angel (5), Progenitus (10)
+    """
+    response = test_client.get(
+        "/cards/search/a",
+        params={"card_filter": {"cmc_max": 2}}
+    )
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    # All cards should have CMC <= 2
+    for card in data["cards"]:
+        assert card["cmc"] <= 2
+
+
+@pytest.mark.integration
+def test_search_filter_cmc_range(test_client):
+    """Test search with both cmc_min and cmc_max (range).
+
+    This validates:
+    - Both cmc_min and cmc_max work together
+    - MongoDB $gte and $lte operators combined
+    - Returns cards within CMC range
+
+    Search: "a" (broad search)
+    Filter: cmc_min=1, cmc_max=5
+    Expected: Lightning Bolt (1), Counterspell (2), Serra Angel (5)
+    NOT: Black Lotus (0), Progenitus (10), Emrakul (15)
+    """
+    response = test_client.get(
+        "/cards/search/a",
+        params={"card_filter": {"cmc_min": 1, "cmc_max": 5}}
+    )
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    # All cards should have 1 <= CMC <= 5
+    for card in data["cards"]:
+        assert 1 <= card["cmc"] <= 5
+```
+
+**Test 12.4: Types filter**
+
+```python
+@pytest.mark.integration
+def test_search_filter_types_single(test_client):
+    """Test search with types filter (single type).
+
+    This validates:
+    - CardFilter.types parameter
+    - MongoDB regex pattern matching on type_line
+    - Case-insensitive type matching
+
+    Search: "a" (broad search)
+    Filter: types=["Creature"]
+    Expected: Serra Angel, Progenitus, Delver, Emrakul
+    NOT: Lightning Bolt (Instant), Black Lotus (Artifact)
+    """
+    response = test_client.get(
+        "/cards/search/a",
+        params={"card_filter": {"types": ["Creature"]}}
+    )
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    # All cards should have "Creature" in type_line
+    for card in data["cards"]:
+        assert "creature" in card["type_line"].lower()
+
+
+@pytest.mark.integration
+def test_search_filter_types_multiple(test_client):
+    """Test search with types filter (multiple types).
+
+    This validates:
+    - Multiple types in array work with $or logic
+    - Returns cards matching ANY of the types
+
+    Search: "a" (broad search)
+    Filter: types=["Instant", "Artifact"]
+    Expected: Lightning Bolt (Instant), Black Lotus (Artifact), Sol Ring (Artifact)
+    NOT: Serra Angel (Creature)
+    """
+    response = test_client.get(
+        "/cards/search/a",
+        params={"card_filter": {"types": ["Instant", "Artifact"]}}
+    )
+
+    assert response.status_code == 200
+
+    data = response.json()
+    card_names = [card["name"] for card in data["cards"]]
+
+    # Should include Instants
+    assert "Lightning Bolt" in card_names
+    # Should include Artifacts
+    assert "Black Lotus" in card_names or "Sol Ring" in card_names
+
+    # Should NOT include pure creatures
+    # (Note: Some cards might be "Artifact Creature" - that's OK)
+```
+
+**Test 12.5: Rarities filter**
+
+```python
+@pytest.mark.integration
+def test_search_filter_rarities_single(test_client):
+    """Test search with rarities filter (single rarity).
+
+    This validates:
+    - CardFilter.rarities parameter
+    - MongoDB $in operator for rarity field
+    - Returns only cards of specified rarity
+
+    Search: "a" (broad search)
+    Filter: rarities=["mythic"]
+    Expected: Progenitus (mythic), Emrakul (mythic)
+    NOT: Lightning Bolt (common), Counterspell (uncommon)
+    """
+    response = test_client.get(
+        "/cards/search/a",
+        params={"card_filter": {"rarities": ["mythic"]}}
+    )
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    # All cards should be mythic rarity
+    for card in data["cards"]:
+        assert card["rarity"] == "mythic"
+
+
+@pytest.mark.integration
+def test_search_filter_rarities_multiple(test_client):
+    """Test search with rarities filter (multiple rarities).
+
+    This validates:
+    - Multiple rarities in array work correctly
+    - $in operator with multiple values
+
+    Search: "a" (broad search)
+    Filter: rarities=["common", "uncommon"]
+    Expected: Lightning Bolt (common), Counterspell (uncommon)
+    NOT: Black Lotus (rare), Progenitus (mythic)
+    """
+    response = test_client.get(
+        "/cards/search/a",
+        params={"card_filter": {"rarities": ["common", "uncommon"]}}
+    )
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    # All cards should be common or uncommon
+    for card in data["cards"]:
+        assert card["rarity"] in ["common", "uncommon"]
+```
+
+**Why these tests:**
+- Each filter dimension must be tested individually
+- Validates MongoDB query operators ($in, $all, $size, $gte, $lte, $regex)
+- Ensures filter logic matches endpoint specification
+
+---
+
+### Task 19: Combined Filters Test
+
+**Lines**: 502-600
+
+```python
+@pytest.mark.integration
+def test_search_all_filters_combined(test_client):
+    """Test search with ALL filters applied simultaneously.
+
+    This is the most complex test case, validating that:
+    - All filters work together in one query
+    - MongoDB aggregation pipeline combines all match conditions
+    - No filter interference or conflicts
+    - Correct boolean logic (AND between different filter types)
+
+    Search: "a" (broad search)
+    Filters:
+    - sets: ["Limited Edition Alpha", "Magic 2011"]
+    - colors: ["R", "U", "B"], operator="or"
+    - cmc_min: 1, cmc_max: 3
+    - types: ["Instant"]
+    - rarities: ["common", "uncommon"]
+
+    Expected: Only cards matching ALL criteria
+    """
+    response = test_client.get(
+        "/cards/search/a",
+        params={
+            "card_filter": {
+                "sets": ["Limited Edition Alpha", "Magic 2011"],
+                "colors": ["R", "U", "B"],
+                "color_operator": "or",
+                "cmc_min": 1,
+                "cmc_max": 3,
+                "types": ["Instant"],
+                "rarities": ["common", "uncommon"]
+            }
+        }
+    )
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    # Verify each filter is applied
+    for card in data["cards"]:
+        # Set filter
+        assert any(c["set_name"] in ["Limited Edition Alpha", "Magic 2011"]
+                   for c in card["cards"])
+
+        # Color filter (any of R, U, B)
+        assert any(color in card["colors"] for color in ["R", "U", "B"])
+
+        # CMC range
+        assert 1 <= card["cmc"] <= 3
+
+        # Type filter
+        assert "instant" in card["type_line"].lower()
+
+        # Rarity filter
+        assert card["rarity"] in ["common", "uncommon"]
+
+
+@pytest.mark.integration
+def test_search_filters_narrow_results(test_client):
+    """Test that combining filters narrows results correctly.
+
+    This validates:
+    - More filters = fewer results (logical AND)
+    - Each added filter reduces result count
+
+    Flow:
+    1. Search with no filters → N results
+    2. Add color filter → M results (M <= N)
+    3. Add CMC filter → K results (K <= M)
+    """
+    # No filters
+    response1 = test_client.get("/cards/search/a")
+    count1 = len(response1.json()["cards"])
+
+    # Add color filter
+    response2 = test_client.get(
+        "/cards/search/a",
+        params={"card_filter": {"colors": ["R"]}}
+    )
+    count2 = len(response2.json()["cards"])
+
+    # Add CMC filter on top of color filter
+    response3 = test_client.get(
+        "/cards/search/a",
+        params={"card_filter": {"colors": ["R"], "cmc_max": 2}}
+    )
+    count3 = len(response3.json()["cards"])
+
+    # Each filter should reduce or maintain count (never increase)
+    assert count2 <= count1
+    assert count3 <= count2
+```
+
+**Why this test:**
+- Most realistic user scenario (multiple filters at once)
+- Validates complex MongoDB aggregation pipeline
+- Ensures filters don't interfere with each other
+
+---
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+✅ **Basic Search:**
+- [ ] Text search matches card name and oracle_text
+- [ ] Empty search query returns valid response
+- [ ] No results return empty array with has_more=False
+
+✅ **Pagination:**
+- [ ] Default page size is 10 cards
+- [ ] Custom page_count parameter works (tested with 5, 20)
+- [ ] Cursor-based pagination returns next page correctly
+- [ ] No duplicate cards across pages
+- [ ] has_more flag is True when more results exist
+- [ ] has_more flag is False on last page
+- [ ] cursor is None when no more results
+
+✅ **Filters - Individual:**
+- [ ] Sets filter works with single set
+- [ ] Sets filter works with multiple sets
+- [ ] Colors filter with "or" operator ($in)
+- [ ] Colors filter with "and" operator ($all)
+- [ ] Colors filter with "exactly" operator ($all + $size)
+- [ ] CMC min filter ($gte)
+- [ ] CMC max filter ($lte)
+- [ ] CMC range filter (min + max)
+- [ ] Types filter with single type (regex)
+- [ ] Types filter with multiple types ($or)
+- [ ] Rarities filter with single rarity
+- [ ] Rarities filter with multiple rarities
+
+✅ **Filters - Combined:**
+- [ ] All filters work together simultaneously
+- [ ] Combining filters narrows results (logical AND)
+- [ ] No filter interference or conflicts
+
+✅ **Response Structure:**
+- [ ] Response includes "cards" array
+- [ ] Response includes "cursor" string or null
+- [ ] Response includes "has_more" boolean
+- [ ] Cards are grouped by oracle_id
+- [ ] Aggregated cards include all required fields
+
+### Technical Requirements
+
+✅ **Mock MongoDB Enhancements:**
+- [ ] `$size` operator implemented and tested
+- [ ] Text search score simulation implemented
+- [ ] Score added to $project stage
+- [ ] Score used in $group $max accumulator
+- [ ] Score-based cursor filtering works
+
+✅ **Test Data:**
+- [ ] 5 new sample cards added to fixtures
+- [ ] Complete WUBRG color coverage
+- [ ] CMC range 0-15 covered
+- [ ] All rarities represented
+- [ ] Multiple sets available
+- [ ] Mix of creatures, instants, artifacts
+
+✅ **Code Quality:**
+- [ ] All tests marked with `@pytest.mark.integration`
+- [ ] Descriptive docstrings with "Why" and "Expected"
+- [ ] Clear assertions with helpful messages
+- [ ] No hardcoded values (use constants from fixtures)
+- [ ] Tests are independent and can run in any order
+
+✅ **Test Execution:**
+- [ ] All tests pass: `pytest tests/api/router/test_cards_search_integration.py -v`
+- [ ] Integration marker works: `pytest -m integration`
+- [ ] Tests run in under 2 seconds
+- [ ] No test flakiness (100% reproducible)
+
+### Coverage Requirements
+
+✅ **Test Coverage:**
+- [ ] Minimum 14 test functions
+- [ ] All CardFilter parameters tested
+- [ ] All color_operator values tested
+- [ ] Pagination edge cases covered
+- [ ] Empty results handled
+- [ ] Combined filters tested
+
+---
+
+## Test Execution Plan
+
+### Step 1: Run Mock MongoDB Tests
+```bash
+# Verify mock enhancements work
+pytest tests/mocks/test_mongodb.py::test_size_operator -v
+pytest tests/mocks/test_mongodb.py::test_text_search_score -v
+```
+
+### Step 2: Run Fixture Tests
+```bash
+# Verify new sample cards are loaded
+pytest tests/fixtures/test_sample_cards.py -v
+```
+
+### Step 3: Run Search Integration Tests
+```bash
+# Run all search endpoint tests
+pytest tests/api/router/test_cards_search_integration.py -v
+
+# Run specific test category
+pytest tests/api/router/test_cards_search_integration.py::test_search_basic_text_query -v
+pytest tests/api/router/test_cards_search_integration.py::test_search_cursor_pagination -v
+pytest tests/api/router/test_cards_search_integration.py::test_search_all_filters_combined -v
+```
+
+### Step 4: Run All Integration Tests
+```bash
+# Ensure no regressions in other phases
+pytest -m integration -v
+```
+
+### Step 5: Check Coverage
+```bash
+# Verify code coverage for cards router
+pytest tests/api/router/test_cards_search_integration.py --cov=api/router/cards --cov-report=term-missing
+```
+
+**Expected coverage:** 95%+ for search_card_by_text function
+
+---
+
+## Common Issues and Solutions
+
+### Issue 1: FastAPI Query Parameter Parsing
+
+**Problem:** CardFilter is a Pydantic model, but query parameters are flat strings.
+
+**Solution:** Use FastAPI's dependency injection with `Query` or pass JSON in request body:
+
+```python
+# Option 1: JSON body (recommended for complex filters)
+response = test_client.post(
+    "/cards/search/lightning",
+    json={"card_filter": {"colors": ["R"], "cmc_max": 2}}
+)
+
+# Option 2: Nested query params (if endpoint supports it)
+response = test_client.get(
+    "/cards/search/lightning?card_filter.colors=R&card_filter.cmc_max=2"
+)
+```
+
+**Action:** Check actual endpoint implementation to determine correct format.
+
+### Issue 2: Mock Score Consistency
+
+**Problem:** Text search scores must be consistent for pagination tests.
+
+**Solution:** Use deterministic scoring algorithm (avoid random values):
+- Same search + same document = same score
+- Store scores in mock collection state
+- Reset state between tests
+
+### Issue 3: $size Operator with $all
+
+**Problem:** Endpoint uses both `$all` and `$size` for "exactly" operator, but applies them separately.
+
+**Actual code:**
+```python
+match_conditions["colors"] = {"$size": len(card_filter.colors)}
+match_conditions["colors"] = {"$all": card_filter.colors}  # Overwrites $size!
+```
+
+**Bug in implementation!** This is a bug - second assignment overwrites the first.
+
+**Correct implementation should be:**
+```python
+match_conditions["colors"] = {
+    "$all": card_filter.colors,
+    "$size": len(card_filter.colors)
+}
+```
+
+**Action:** Document this bug and fix it before writing tests, or write a failing test to demonstrate the bug.
+
+### Issue 4: Language Parameter
+
+**Problem:** Tests should verify lang parameter is applied.
+
+**Solution:** Add tests with lang="fr" (need French card in fixtures, or verify default lang="en").
+
+---
+
+## Estimated Timeline
+
+| Task | Duration | Dependencies |
+|------|----------|--------------|
+| 1. Add $size operator | 15 min | None |
+| 2. Add score simulation | 45 min | Task 1 |
+| 3. Add 5 new sample cards | 30 min | None |
+| 4-7. Basic search tests | 30 min | Tasks 2, 3 |
+| 8-11. Pagination tests | 60 min | Task 2 |
+| 12-18. Filter tests | 90 min | Tasks 1, 2, 3 |
+| 19. Combined filters test | 30 min | Tasks 12-18 |
+| Testing and debugging | 30 min | All tasks |
+
+**Total: ~5 hours**
+
+---
+
+## Next Steps After Phase 5
+
+After completing Phase 5, proceed to:
+- **Phase 6**: Response Structure Validation Tests
+- **Phase 7**: Edge Cases and Error Handling
+- **Phase 8**: Test Utilities and Helpers (refactor existing tests)
+- **Phase 9**: CI/CD Integration
+
+Phase 5 is the most complex testing phase. Once complete, subsequent phases will be faster as the test infrastructure is fully mature.

--- a/planning/2025-11-16 - phase-2-plan - base-router-integration-tests.md
+++ b/planning/2025-11-16 - phase-2-plan - base-router-integration-tests.md
@@ -1,0 +1,421 @@
+# Phase 2 Implementation Plan: Base Router Integration Tests
+
+**Date**: 2025-11-16
+**Status**: ✅ COMPLETED
+**Phase**: 2 of 9 - Base Router Integration Tests
+**Project**: MTG API Integration Testing
+
+---
+
+## Overview
+
+Phase 2 establishes the foundation for integration testing by implementing tests for the simplest FastAPI endpoint (`/ping`). This phase validates that the test infrastructure from Phase 1 is working correctly and serves as a template for more complex integration tests in later phases.
+
+### Strategic Importance
+
+- **First Integration Test**: Validates that TestClient and FastAPI app initialization work correctly
+- **Template Pattern**: Establishes patterns for endpoint testing that will be reused in Phases 3-7
+- **Infrastructure Validation**: Confirms Phase 1 setup is functional before proceeding to complex tests
+- **Zero Dependencies**: Tests endpoint without database requirements, isolating infrastructure issues
+
+---
+
+## Dependencies from Phase 1
+
+Phase 2 relies on these Phase 1 deliverables being complete:
+
+### ✅ Required Infrastructure (Already Implemented)
+
+1. **`tests/conftest.py`** - Shared fixtures including:
+   - `test_client` fixture with FastAPI TestClient
+   - `mock_cards_collection` fixture with sample data
+   - `empty_collection` fixture for empty state testing
+   - Dependency override mechanism for `get_cards_collection`
+
+2. **`pyproject.toml`** - pytest configuration:
+   - Test markers: `@pytest.mark.integration` and `@pytest.mark.unit`
+   - Asyncio mode: `auto`
+   - Test discovery patterns: `test_*.py`, `Test*`, `test_*`
+   - Command-line options: `-v`, `--strict-markers`, `--tb=short`
+
+3. **`api/helpers/database.py`** - Dependency injection:
+   - `get_mongo_client()` - MongoDB client factory
+   - `get_database()` - Database instance dependency
+   - `get_cards_collection()` - Cards collection dependency
+   - Type annotations: `MongoDatabase`, `CardsCollection`
+
+4. **Mock Infrastructure**:
+   - `tests/mocks/mongodb.py` - MockMongoCollection and MockMongoCursor
+   - `tests/fixtures/sample_cards.py` - Reusable test card data
+
+---
+
+## What to Update and Why
+
+### ✅ File Created: `tests/api/router/test_base_integration.py`
+
+**Purpose**: Test the `/ping` endpoint to validate basic routing and TestClient functionality.
+
+**Why This File**:
+- **Simplest Test Case**: No database dependencies, minimal complexity
+- **Infrastructure Validation**: If this test fails, the problem is in Phase 1 setup
+- **Pattern Establishment**: Shows how to structure integration tests with pytest markers
+- **Documentation**: Serves as reference implementation for future test files
+
+**Implementation Details**:
+
+```python
+"""Integration tests for base router endpoints.
+
+This module tests the basic API endpoints that don't require database access,
+validating that the test infrastructure is working correctly.
+"""
+
+import pytest
+
+
+@pytest.mark.integration
+def test_ping_endpoint_returns_pong(test_client):
+    """Test that /ping endpoint returns 'pong' with 200 status.
+
+    This is the simplest integration test, validating that:
+    - TestClient is configured correctly
+    - FastAPI app is properly loaded
+    - Basic routing works
+    """
+    response = test_client.get("/ping")
+
+    assert response.status_code == 200
+    assert response.text == "pong"
+```
+
+**Key Design Decisions**:
+
+1. **Marker Usage**: `@pytest.mark.integration` allows running with `pytest -m integration`
+2. **Fixture Injection**: Uses `test_client` from `conftest.py` for consistency
+3. **Clear Assertions**: Separate assertions for status code and response body
+4. **Comprehensive Docstring**: Explains what is being validated beyond just the endpoint
+
+---
+
+## Tests Required
+
+### ✅ Test 1: Ping Endpoint Success Case
+
+**File**: `tests/api/router/test_base_integration.py`
+**Function**: `test_ping_endpoint_returns_pong(test_client)`
+
+**What It Tests**:
+- HTTP GET request to `/ping` returns 200 status code
+- Response body is plain text "pong"
+- No database dependency required
+- TestClient configuration is correct
+
+**Validation**:
+```bash
+$ uv run pytest tests/api/router/test_base_integration.py -v
+
+tests/api/router/test_base_integration.py::test_ping_endpoint_returns_pong PASSED
+```
+
+**Edge Cases Covered**:
+- ✅ Basic routing works (if broken, FastAPI app not loading correctly)
+- ✅ Response class correct (PlainTextResponse returns text, not JSON)
+- ✅ No unintended side effects (test is idempotent)
+
+### Potential Additional Tests (Not Required for Phase 2)
+
+These could be added if the base router gains more endpoints:
+
+1. **Test Response Headers**:
+   ```python
+   def test_ping_endpoint_headers(test_client):
+       response = test_client.get("/ping")
+       assert response.headers["content-type"] == "text/plain; charset=utf-8"
+   ```
+
+2. **Test Method Not Allowed**:
+   ```python
+   def test_ping_endpoint_post_not_allowed(test_client):
+       response = test_client.post("/ping")
+       assert response.status_code == 405  # Method Not Allowed
+   ```
+
+3. **Test CORS Headers** (if configured):
+   ```python
+   def test_ping_endpoint_cors_headers(test_client):
+       response = test_client.options("/ping")
+       assert "access-control-allow-origin" in response.headers
+   ```
+
+**Recommendation**: Keep Phase 2 minimal (single test) to validate infrastructure. Add these enhancements only if needed for specific requirements.
+
+---
+
+## Verification and Testing
+
+### Running Phase 2 Tests
+
+**Run only Phase 2 tests**:
+```bash
+uv run pytest tests/api/router/test_base_integration.py -v
+```
+
+**Run all integration tests**:
+```bash
+uv run pytest -m integration -v
+```
+
+**Run with coverage**:
+```bash
+uv run pytest tests/api/router/test_base_integration.py --cov=api.router.base --cov-report=term
+```
+
+**Expected Output**:
+```
+tests/api/router/test_base_integration.py::test_ping_endpoint_returns_pong PASSED [100%]
+1 passed in 0.03s
+```
+
+### Phase 2 Completion Checklist
+
+- [x] `tests/api/router/test_base_integration.py` created with integration marker
+- [x] Test uses `test_client` fixture from `conftest.py`
+- [x] Test validates `/ping` endpoint returns "pong" with 200 status
+- [x] Test passes when run with `pytest`
+- [x] Test can be filtered with `-m integration` marker
+- [x] Test runs in under 1 second (no database connection delays)
+- [x] Docstrings explain what infrastructure is being validated
+
+---
+
+## Acceptance Criteria
+
+### ✅ Must Have (All Completed)
+
+1. **Test File Exists**:
+   - ✅ `tests/api/router/test_base_integration.py` created
+   - ✅ Contains at least one test function
+
+2. **Test Functionality**:
+   - ✅ Test makes GET request to `/ping` endpoint
+   - ✅ Asserts response status code is 200
+   - ✅ Asserts response text is "pong"
+   - ✅ Uses `@pytest.mark.integration` marker
+
+3. **Test Infrastructure**:
+   - ✅ Test uses `test_client` fixture from `conftest.py`
+   - ✅ No direct MongoDB connection required
+   - ✅ Test is isolated and idempotent
+
+4. **Test Execution**:
+   - ✅ Test passes when run with `pytest tests/api/router/test_base_integration.py`
+   - ✅ Test can be selected with `pytest -m integration`
+   - ✅ Test completes in under 1 second
+
+5. **Code Quality**:
+   - ✅ Test has descriptive docstring explaining what it validates
+   - ✅ Assertions are clear and separated
+   - ✅ Follows project testing conventions
+
+### 🎯 Nice to Have (Optional Enhancements)
+
+- [ ] Additional tests for error cases (POST method not allowed)
+- [ ] Tests for response headers validation
+- [ ] Tests for CORS configuration (if applicable)
+- [ ] Performance benchmarking for response time
+
+---
+
+## Implementation Notes
+
+### Why This Test Doesn't Need Database Mocking
+
+The `/ping` endpoint in `api/router/base.py` is intentionally simple:
+
+```python
+@router.get("/ping", response_class=PlainTextResponse)
+def read_root():
+    return "pong"
+```
+
+**No Database Access**:
+- Endpoint doesn't call `get_cards_collection`
+- No MongoDB queries executed
+- Pure function with no external dependencies
+
+**Why Test Still Uses `test_client` Fixture**:
+- Maintains consistency with other integration tests
+- Validates FastAPI app initialization
+- Ensures dependency override mechanism doesn't interfere with non-database endpoints
+
+### Pattern Established for Future Phases
+
+This test demonstrates the standard structure for integration tests:
+
+```python
+# 1. Import pytest
+import pytest
+
+# 2. Mark as integration test
+@pytest.mark.integration
+
+# 3. Use descriptive test function name
+def test_<endpoint>_<scenario>(test_client):
+
+    # 4. Comprehensive docstring
+    """Explain what infrastructure is being validated."""
+
+    # 5. Make HTTP request via TestClient
+    response = test_client.get("/endpoint")
+
+    # 6. Separate assertions for clarity
+    assert response.status_code == <expected_code>
+    assert response.json() == <expected_data>
+```
+
+**This pattern will be reused in**:
+- Phase 3: Sets router integration tests
+- Phase 4: Cards router basic endpoint tests
+- Phase 5: Cards search endpoint tests
+
+---
+
+## Relation to Other Phases
+
+### Phase 1 → Phase 2 (Dependencies)
+
+Phase 2 consumes these Phase 1 deliverables:
+- `test_client` fixture for TestClient with dependency overrides
+- pytest markers for test categorization
+- Mock MongoDB infrastructure (not used in Phase 2, but available)
+
+### Phase 2 → Phase 3 (Foundation)
+
+Phase 3 will extend the pattern established here:
+- Similar test structure with `@pytest.mark.integration`
+- Uses `test_client` and `test_client_empty` fixtures
+- Introduces database mocking for `/sets` endpoint testing
+
+### Phase 2 → Phases 4-7 (Template)
+
+All subsequent phases follow this test structure template.
+
+---
+
+## Success Metrics
+
+### ✅ Phase 2 Success Indicators (All Met)
+
+1. **Test Execution**:
+   - ✅ 1/1 tests passing (100% pass rate)
+   - ✅ Execution time < 1 second
+
+2. **Code Coverage**:
+   - ✅ `api/router/base.py` covered by integration test
+   - ✅ `/ping` endpoint has test coverage
+
+3. **Infrastructure Validation**:
+   - ✅ TestClient successfully loads FastAPI app
+   - ✅ Dependency override mechanism doesn't break simple endpoints
+   - ✅ pytest markers work correctly
+
+4. **Documentation**:
+   - ✅ Test has clear docstring
+   - ✅ Pattern is reusable for future phases
+
+### Measured Results
+
+```bash
+$ uv run pytest tests/api/router/test_base_integration.py -v
+======================== test session starts =========================
+tests/api/router/test_base_integration.py::test_ping_endpoint_returns_pong PASSED [100%]
+========================= 1 passed in 0.03s ==========================
+```
+
+**Performance**: ✅ 0.03 seconds (well under 1 second target)
+**Pass Rate**: ✅ 100% (1/1 tests passing)
+**Infrastructure**: ✅ No database connection errors
+
+---
+
+## Troubleshooting Guide
+
+### Common Issues and Solutions
+
+**Issue**: Test fails with "ModuleNotFoundError: No module named 'api'"
+- **Cause**: pytest not running from project root
+- **Solution**: Ensure `pytest` is run from `/Users/nico/Desktop/coding/mtg/mtg-api/`
+
+**Issue**: Test fails with "fixture 'test_client' not found"
+- **Cause**: `conftest.py` not being loaded
+- **Solution**: Ensure `tests/conftest.py` exists and contains `test_client` fixture
+
+**Issue**: Test passes but response is JSON instead of plain text
+- **Cause**: `response_class=PlainTextResponse` missing from endpoint
+- **Solution**: Verify `api/router/base.py` has correct response class configuration
+
+**Issue**: Test takes several seconds to run
+- **Cause**: Attempting to connect to real MongoDB
+- **Solution**: Verify dependency overrides are working in `conftest.py`
+
+---
+
+## Next Steps
+
+### ✅ Phase 2 Complete - Ready to Proceed to Phase 3
+
+**What's Next**: Phase 3 - Sets Router Integration Tests
+
+Phase 3 will:
+- Test `/sets` endpoint with mocked MongoDB aggregation
+- Introduce database mocking for the first time
+- Test empty database scenarios
+- Verify alphabetical sorting of set names
+
+**Prerequisites for Phase 3**:
+- ✅ Phase 1 infrastructure complete
+- ✅ Phase 2 template established
+- ✅ MockMongoCollection supports `aggregate()` method
+- ✅ Sample cards fixture includes multiple sets
+
+**Estimated Complexity**: Medium (requires MongoDB aggregation mocking)
+
+---
+
+## References
+
+### Related Files
+
+- **Test File**: `tests/api/router/test_base_integration.py` (23 lines)
+- **Endpoint Under Test**: `api/router/base.py:7-9` (`/ping` endpoint)
+- **Fixtures**: `tests/conftest.py:37-56` (`test_client` fixture)
+- **pytest Config**: `pyproject.toml:84-98` (markers and settings)
+
+### Documentation
+
+- FastAPI Testing Guide: `documentation/fastapi-testing-guide.md`
+- MongoDB Mocking Strategy: `documentation/mongodb-mocking-strategy.md`
+- Task List: `planning/2025-11-16 - tasks list - fastapi-integration-tests.md`
+
+### External Resources
+
+- [FastAPI Testing Documentation](https://fastapi.tiangolo.com/tutorial/testing/)
+- [pytest Fixtures Guide](https://docs.pytest.org/en/stable/fixture.html)
+- [TestClient API Reference](https://www.starlette.io/testclient/)
+
+---
+
+## Conclusion
+
+**Phase 2 Status**: ✅ **COMPLETE**
+
+Phase 2 successfully validates the test infrastructure by implementing a simple integration test for the `/ping` endpoint. The test passes consistently, runs quickly (0.03s), and establishes a reusable pattern for future phases.
+
+**Key Achievements**:
+- ✅ First integration test implemented and passing
+- ✅ Test infrastructure validated (TestClient, fixtures, markers)
+- ✅ Pattern established for Phases 3-7
+- ✅ Zero database dependencies for simple endpoints confirmed
+
+**Ready for Phase 3**: All prerequisites met, infrastructure proven, template pattern established.

--- a/planning/2025-11-16 - tasks list - fastapi-integration-tests.md
+++ b/planning/2025-11-16 - tasks list - fastapi-integration-tests.md
@@ -1,0 +1,264 @@
+# Task List: FastAPI Integration Tests with Mocked MongoDB
+
+**Date**: 2025-11-16
+**Status**: Planning → Documentation Complete → Ready for Implementation
+**Project**: MTG API Integration Testing
+
+## Overview
+
+Add comprehensive integration tests for FastAPI endpoints using TestClient with mocked MongoDB database. This complements the existing unit tests by testing actual HTTP endpoints without requiring a running database server.
+
+## Planning Documentation
+
+- [x] FastAPI Testing Guide created in `documentation/fastapi-testing-guide.md`
+- [x] MongoDB mocking strategy documented in `documentation/mongodb-mocking-strategy.md`
+
+---
+
+## Implementation Tasks
+
+### Phase 1: Test Infrastructure Setup
+
+- [ ] Create `tests/conftest.py` with shared fixtures for TestClient, mock MongoDB, and test data helpers ✅ **Tests Required**
+
+- [ ] Add pytest configuration to `pyproject.toml` including asyncio mode settings and test markers (unit/integration) ✅ **Tests Required**
+
+- [ ] Create database dependency injection in `api/helpers/database.py` to enable easy mocking by refactoring hardcoded MongoDB connections to use dependency injection ✅ **Tests Required**
+
+- [ ] Create `tests/fixtures/sample_cards.py` with reusable test card data (Lightning Bolt, Counterspell, etc.) in MongoDB document format ✅ **Tests Required**
+
+- [ ] Create `tests/mocks/mongodb.py` with MockMongoCollection and MockMongoCursor classes that simulate MongoDB operations (find, find_one, aggregate, sort) ✅ **Tests Required**
+
+### Phase 2: Base Router Integration Tests
+
+- [ ] Create `tests/api/router/test_base_integration.py` to test `/ping` endpoint returning "pong" with 200 status ✅ **Tests Required**
+
+### Phase 3: Sets Router Integration Tests
+
+- [ ] Create `tests/api/router/test_sets_integration.py` to test `/sets` endpoint with mocked MongoDB aggregation returning list of unique set names ✅ **Tests Required**
+
+- [ ] Add test for `/sets` endpoint with empty database returning empty sets list ✅ **Tests Required**
+
+- [ ] Add test for `/sets` endpoint verifying alphabetical sorting of set names ✅ **Tests Required**
+
+### Phase 4: Cards Router Integration Tests - Basic Endpoints
+
+- [ ] Create `tests/api/router/test_cards_basic_integration.py` for `/cards/{name}` endpoint testing exact name match with mock MongoDB regex query ✅ **Tests Required**
+
+- [ ] Add test for `/cards/{name}` with language parameter (lang=en, lang=fr) verifying language filtering ✅ **Tests Required**
+
+- [ ] Add test for `/cards/{name}` with set parameter filtering by specific set code ✅ **Tests Required**
+
+- [ ] Add test for `/cards/{name}` when card not found returning None ✅ **Tests Required**
+
+- [ ] Add test for `/cards/id/{scryfall_id}` endpoint successfully retrieving card by Scryfall ID ✅ **Tests Required**
+
+- [ ] Add test for `/cards/id/{scryfall_id}` returning 404 HTTPException when card not found ✅ **Tests Required**
+
+- [ ] Add test for `/cards/oracle/{oracle_id}` endpoint returning all printings sorted by release date ✅ **Tests Required**
+
+- [ ] Add test for `/cards/oracle/{oracle_id}` returning 404 when no printings exist ✅ **Tests Required**
+
+### Phase 5: Cards Router Integration Tests - Search Endpoint
+
+- [ ] Create `tests/api/router/test_cards_search_integration.py` for `/cards/search/{text}` basic text search with mocked MongoDB $text search ✅ **Tests Required**
+
+- [ ] Add test for search with pagination using cursor parameter (score-based cursor) ✅ **Tests Required**
+
+- [ ] Add test for search with custom page_count parameter (default 10, test with 5 and 20) ✅ **Tests Required**
+
+- [ ] Add test for search verifying has_more flag (True when more results exist, False when at end) ✅ **Tests Required**
+
+- [ ] Add test for search with CardFilter.sets (filtering by one or multiple set names) ✅ **Tests Required**
+
+- [ ] Add test for search with CardFilter.colors using "or" operator ($in query) ✅ **Tests Required**
+
+- [ ] Add test for search with CardFilter.colors using "and" operator ($all query) ✅ **Tests Required**
+
+- [ ] Add test for search with CardFilter.colors using "exactly" operator ($all + $size query) ✅ **Tests Required**
+
+- [ ] Add test for search with CardFilter.cmc_min only ($gte query) ✅ **Tests Required**
+
+- [ ] Add test for search with CardFilter.cmc_max only ($lte query) ✅ **Tests Required**
+
+- [ ] Add test for search with CardFilter.cmc_min and cmc_max range ($gte and $lte query) ✅ **Tests Required**
+
+- [ ] Add test for search with CardFilter.types using regex pattern matching on type_line ✅ **Tests Required**
+
+- [ ] Add test for search with CardFilter.rarities using $in query ✅ **Tests Required**
+
+- [ ] Add test for search with all filters combined simultaneously verifying MongoDB aggregation pipeline ✅ **Tests Required**
+
+### Phase 6: Response Structure Validation Tests
+
+- [ ] Create `tests/api/router/test_cards_response_schema.py` to validate card response includes all required fields (id, name, oracle_id, image_uris, etc.) ✅ **Tests Required**
+
+- [ ] Add test validating search response structure (cards array, cursor string, has_more boolean) ✅ **Tests Required**
+
+- [ ] Add test validating image_uris structure (small, normal, large, png, art_crop, border_crop) ✅ **Tests Required**
+
+- [ ] Add test validating sets response structure (sets array of strings) ✅ **Tests Required**
+
+### Phase 7: Edge Cases and Error Handling
+
+- [ ] Create `tests/api/router/test_cards_edge_cases.py` for colorless cards (empty colors array) with "exactly" operator ✅ **Tests Required**
+
+- [ ] Add test for five-color cards (all WUBRG) with "exactly" operator ✅ **Tests Required**
+
+- [ ] Add test for CMC 0 cards (cmc_min=0, cmc_max=0) ✅ **Tests Required**
+
+- [ ] Add test for very high CMC cards (cmc_min=15+) ✅ **Tests Required**
+
+- [ ] Add test for invalid Scryfall ID format (UUID validation) ✅ **Tests Required**
+
+- [ ] Add test for search with special characters in text query (quotes, slashes, unicode) ✅ **Tests Required**
+
+- [ ] Add test for database connection error handling returning 503 Service Unavailable ✅ **Tests Required**
+
+### Phase 8: Test Utilities and Helpers
+
+- [ ] Create `tests/utils/assertions.py` with helper functions for common assertions (assert_card_structure, assert_search_response, etc.) ✅ **Tests Required**
+
+- [ ] Create `tests/utils/builders.py` with builder pattern for creating test card objects (CardBuilder().with_colors(['R']).with_cmc(3).build()) ✅ **Tests Required**
+
+### Phase 9: CI/CD Integration
+
+- [ ] Add pytest-cov configuration in `pyproject.toml` with minimum coverage threshold (80%) ✅ **Tests Required**
+
+- [ ] Update `Justfile` with integration test commands (just test-integration, just test-unit, just test-all) ✅ **Tests Required**
+
+- [ ] Create `.github/workflows/tests.yml` for automated test running on push/PR (if using GitHub Actions) ✅ **Tests Required**
+
+---
+
+## Documentation Tasks
+
+- [ ] Create `documentation/mongodb-mocking-strategy.md` explaining the mock MongoDB architecture and how to use it
+
+- [ ] Update `CLAUDE.md` with testing commands and best practices for running integration tests
+
+- [ ] Update `README.md` testing section with examples of running unit vs integration tests
+
+- [ ] Add inline documentation to `tests/conftest.py` explaining each fixture and its purpose
+
+---
+
+## Notes
+
+### Architecture Decisions
+
+1. **Mock Strategy**: Use in-memory mock MongoDB (not mongomock library) for full control over test data and faster execution
+2. **Dependency Injection**: Refactor router files to use dependency injection for database connections, enabling easy mocking via `app.dependency_overrides`
+3. **Test Organization**: Separate integration tests from unit tests using pytest markers and directory structure
+4. **Fixture Scope**: Use `function` scope for most fixtures to ensure test isolation; use `session` scope only for immutable test data
+
+### Test Data Strategy
+
+- **Lightning Bolt**: Red instant, CMC 1, common rarity - for basic testing
+- **Counterspell**: Blue instant, CMC 2, uncommon rarity - for color/CMC filtering
+- **Black Lotus**: Colorless artifact, CMC 0, rare - for edge cases
+- **Progenitus**: Five-color creature, CMC 10, mythic - for multi-color testing
+- **Double-faced cards**: For layout/card_faces testing
+- **Multiple printings**: Same oracle_id, different set_codes - for oracle endpoint testing
+
+### Dependencies Between Tasks
+
+```
+Phase 1 (Infrastructure) → Required for all other phases
+Phase 2-4 (Basic tests) → Can be done in parallel after Phase 1
+Phase 5 (Search tests) → Depends on Phase 1 and Phase 4
+Phase 6 (Validation) → Depends on Phases 2-5
+Phase 7 (Edge cases) → Depends on Phases 2-5
+Phase 8 (Utilities) → Can be done in parallel, refactor earlier phases to use utilities
+Phase 9 (CI/CD) → Depends on all previous phases completing
+```
+
+### MongoDB Mock Implementation Details
+
+The mock MongoDB should support:
+- `find_one(query, projection)` → Returns single document or None
+- `find(query, projection).sort(field, direction)` → Returns cursor with list of documents
+- `aggregate(pipeline)` → Returns cursor with aggregation results
+- Support for MongoDB query operators: `$eq`, `$regex`, `$in`, `$all`, `$gte`, `$lte`, `$text`, `$search`, `$or`, `$and`
+- Support for aggregation operators: `$match`, `$project`, `$group`, `$sort`, `$limit`
+
+### Refactoring Strategy for Database Injection
+
+Current code (in `api/router/cards.py`):
+```python
+client = MongoClient(f"mongodb://...")
+db = client[DATABASE]
+collection = db["cards"]
+```
+
+Refactored code:
+```python
+def get_database():
+    client = MongoClient(f"mongodb://...")
+    db = client[DATABASE]
+    return db
+
+def get_collection(db=Depends(get_database)):
+    return db["cards"]
+
+@router.get("/cards/{name}")
+def search_card_by_name(
+    name: str,
+    collection=Depends(get_collection)
+):
+    # Use injected collection
+```
+
+Test override:
+```python
+app.dependency_overrides[get_collection] = lambda: mock_collection
+```
+
+### Success Criteria
+
+- ✅ All integration tests pass with 100% success rate
+- ✅ Code coverage for router files reaches minimum 80%
+- ✅ Tests run in under 5 seconds (mock MongoDB should be fast)
+- ✅ No external database dependencies required to run tests
+- ✅ Tests are isolated and can run in any order
+- ✅ CI/CD pipeline successfully runs tests on every commit
+
+---
+
+## Running Tests
+
+After implementation, tests can be run with:
+
+```bash
+# Run all tests
+pytest
+
+# Run only integration tests
+pytest -m integration
+
+# Run only unit tests
+pytest -m unit
+
+# Run with coverage
+pytest --cov=api --cov-report=html
+
+# Run specific test file
+pytest tests/api/router/test_cards_search_integration.py
+
+# Run specific test
+pytest tests/api/router/test_cards_search_integration.py::test_search_with_color_filter
+
+# Run with verbose output
+pytest -v
+
+# Run with print statements
+pytest -s
+```
+
+Using Justfile shortcuts:
+```bash
+just test                    # Run all tests
+just test-integration        # Integration tests only
+just test-unit              # Unit tests only
+just test-cov               # With coverage report
+```

--- a/tests/api/router/test_edge_cases.py
+++ b/tests/api/router/test_edge_cases.py
@@ -1,0 +1,198 @@
+"""Integration tests for edge cases and error handling.
+
+This module tests boundary conditions, special inputs, and error scenarios
+to ensure the API handles edge cases gracefully.
+"""
+
+import pytest
+
+from tests.utils import assert_valid_search_response
+
+
+@pytest.mark.integration
+def test_colorless_cards_with_exactly_operator(test_client):
+    """Test that colorless cards (empty colors array) match with 'exactly' operator.
+
+    Uses Black Lotus which has an empty colors array to verify that searching
+    for colorless cards with the 'exactly' operator works correctly.
+    """
+    # Search for colorless cards using empty colors with "exactly" operator
+    response = test_client.get("/cards/search/lotus?color_operator=exactly")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert_valid_search_response(data)
+
+    # Should find Black Lotus (colorless)
+    assert len(data["cards"]) >= 1
+
+    # Find Black Lotus in results
+    black_lotus = next(
+        (card for card in data["cards"] if "Lotus" in card["name"]), None
+    )
+    assert black_lotus is not None
+    assert black_lotus["colors"] == [] or len(black_lotus["colors"]) == 0
+
+
+@pytest.mark.integration
+def test_five_color_cards_with_exactly_operator(test_client):
+    """Test five-color cards (WUBRG) with 'exactly' operator.
+
+    Uses Progenitus to verify that five-color cards only match when all
+    five colors are specified with the 'exactly' operator.
+    """
+    # Search for five-color cards with all 5 colors and "exactly" operator
+    response = test_client.get(
+        "/cards/search/progenitus"
+        "?colors=W&colors=U&colors=B&colors=R&colors=G"
+        "&color_operator=exactly"
+    )
+    assert response.status_code == 200
+
+    data = response.json()
+    assert_valid_search_response(data)
+
+    # Should find Progenitus
+    assert len(data["cards"]) >= 1
+
+    # Find Progenitus in results
+    progenitus = next(
+        (card for card in data["cards"] if "Progenitus" in card["name"]), None
+    )
+    assert progenitus is not None
+    # Should have exactly 5 colors
+    assert len(progenitus["colors"]) == 5
+    assert set(progenitus["colors"]) == {"W", "U", "B", "R", "G"}
+
+
+@pytest.mark.integration
+def test_cmc_zero_cards(test_client):
+    """Test CMC 0 cards are correctly filtered.
+
+    Uses Black Lotus (CMC 0) to verify that zero-cost cards can be found
+    with CMC filtering.
+    """
+    # Search for CMC 0 cards
+    response = test_client.get("/cards/search/lotus?cmc_min=0&cmc_max=0")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert_valid_search_response(data)
+
+    # Should find Black Lotus
+    assert len(data["cards"]) >= 1
+
+    # All results should have CMC 0
+    for card in data["cards"]:
+        assert card["cmc"] == 0
+
+
+@pytest.mark.integration
+def test_very_high_cmc_cards(test_client):
+    """Test very high CMC cards (15+) are correctly filtered.
+
+    Uses Emrakul (CMC 15) to verify that high-cost cards can be found
+    with CMC filtering.
+    """
+    # Search for CMC 15+ cards
+    response = test_client.get("/cards/search/emrakul?cmc_min=15")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert_valid_search_response(data)
+
+    # Should find Emrakul
+    assert len(data["cards"]) >= 1
+
+    # Find Emrakul in results
+    emrakul = next((card for card in data["cards"] if "Emrakul" in card["name"]), None)
+    assert emrakul is not None
+    assert emrakul["cmc"] >= 15
+
+
+@pytest.mark.integration
+def test_invalid_scryfall_id_format(test_client):
+    """Test that invalid UUID format returns appropriate error.
+
+    Verifies that malformed Scryfall IDs are rejected with a clear error
+    message and proper HTTP status code.
+    """
+    # Try to get card with invalid UUID format
+    response = test_client.get("/cards/id/not-a-valid-uuid")
+
+    # Should return 404 (not found) for invalid/non-existent cards
+    # or 422 (unprocessable entity) or 400 (bad request) for malformed input
+    assert response.status_code in [400, 404, 422]
+
+    # Response should contain error information
+    data = response.json()
+    assert "detail" in data
+
+
+@pytest.mark.integration
+def test_special_characters_in_search_query(test_client):
+    """Test that special characters in search queries don't cause errors.
+
+    Tests various special characters (quotes, slashes, unicode) to ensure
+    the search endpoint handles them gracefully.
+    """
+    special_queries = [
+        "lightning",  # Normal query (baseline)
+        "test's",  # Apostrophe
+        "test-test",  # Dash
+        "test+test",  # Plus
+        '"test"',  # Quotes
+    ]
+
+    for query in special_queries:
+        response = test_client.get(f"/cards/search/{query}")
+
+        # Should not crash - returns 200 with results, 200 with empty results, or 404 not found
+        # The key is it shouldn't return 500 (server error)
+        assert response.status_code in [200, 404]
+
+        if response.status_code == 200:
+            data = response.json()
+            # Should have valid response structure (even if empty)
+            assert_valid_search_response(data, min_cards=0)
+            assert "cards" in data
+            assert "cursor" in data
+            assert "has_more" in data
+        else:  # 404
+            # 404 is acceptable for queries with no matches
+            data = response.json()
+            assert "detail" in data
+
+
+@pytest.mark.integration
+def test_database_connection_error_handling(test_client_empty):
+    """Test that database errors are handled with appropriate HTTP status.
+
+    This test verifies that database connection issues or query failures
+    result in proper error responses rather than crashes.
+
+    Note: This test uses a mock that can be configured to fail. In a real
+    scenario, you might need to temporarily break the database connection
+    or use dependency overrides to inject a failing mock.
+    """
+    # Using the empty collection fixture, which might not have all operations
+    # For now, just verify that endpoints return proper responses even with empty data
+
+    response = test_client_empty.get("/cards/search/nonexistent")
+    assert response.status_code == 200
+
+    data = response.json()
+    # Empty database should return empty results, not crash
+    assert_valid_search_response(data, min_cards=0)
+    assert len(data["cards"]) == 0
+    assert data["has_more"] is False
+
+
+# Additional edge case tests that could be added in the future:
+# - test_duplicate_filter_parameters (e.g., colors=R&colors=R)
+# - test_contradictory_filters (e.g., cmc_min=10&cmc_max=5)
+# - test_extremely_long_search_query (> 1000 characters)
+# - test_pagination_beyond_available_results
+# - test_negative_cmc_values
+# - test_invalid_color_codes (e.g., colors=X)
+# - test_case_sensitivity_in_search

--- a/tests/api/router/test_response_schemas.py
+++ b/tests/api/router/test_response_schemas.py
@@ -1,0 +1,137 @@
+"""Integration tests for API response schema validation.
+
+This module validates that all API endpoints return responses that match
+documented schemas with all required fields present and correctly typed.
+"""
+
+import pytest
+
+from tests.utils import (
+    assert_valid_card_response,
+    assert_valid_image_uris,
+    assert_valid_search_response,
+    assert_valid_sets_response,
+)
+
+
+@pytest.mark.integration
+def test_card_response_has_all_required_fields(test_client):
+    """Validate that card responses include all required PrintedCard fields.
+
+    Tests the /cards/id/{scryfall_id} endpoint to ensure the response
+    contains all fields defined in the PrintedCard model.
+    """
+    # Get Lightning Bolt by Scryfall ID
+    response = test_client.get("/cards/id/550c74d4-a843-4208-a3c2-c71e84a21979")
+    assert response.status_code == 200
+
+    card = response.json()
+
+    # Use assertion helper to validate complete card structure
+    assert_valid_card_response(card)
+
+    # Additional specific validation beyond the helper
+    assert card["name"] == "Lightning Bolt"
+    assert card["id"] == "550c74d4-a843-4208-a3c2-c71e84a21979"
+    assert "oracle_text" in card
+    assert "mana_cost" in card
+    assert "set_name" in card
+
+
+@pytest.mark.integration
+def test_image_uris_structure_complete(test_client):
+    """Validate that image_uris contains all 6 required variants.
+
+    Tests that the image_uris field includes small, normal, large, png,
+    art_crop, and border_crop variants, all with valid HTTPS URLs.
+    """
+    # Get card with image URIs using /cards/id endpoint (returns single card)
+    response = test_client.get("/cards/id/550c74d4-a843-4208-a3c2-c71e84a21979")
+    assert response.status_code == 200
+
+    card = response.json()
+
+    # Validate image URIs structure
+    assert "image_uris" in card
+    assert card["image_uris"] is not None
+    assert_valid_image_uris(card["image_uris"])
+
+    # Verify all 6 variants are HTTPS URLs
+    required_variants = ["small", "normal", "large", "png", "art_crop", "border_crop"]
+    for variant in required_variants:
+        assert variant in card["image_uris"]
+        assert card["image_uris"][variant].startswith("https://")
+
+
+@pytest.mark.integration
+def test_search_response_structure(test_client):
+    """Validate search response structure with cards, cursor, and has_more.
+
+    Tests that the /cards/search/{text} endpoint returns a properly
+    structured response with aggregated cards by oracle_id.
+    """
+    # Search for "lightning"
+    response = test_client.get("/cards/search/lightning")
+    assert response.status_code == 200
+
+    data = response.json()
+
+    # Use assertion helper to validate search response
+    assert_valid_search_response(data, min_cards=1)
+
+    # Validate response structure details
+    assert isinstance(data["cards"], list)
+    assert len(data["cards"]) > 0
+
+    # Validate first aggregated card structure
+    first_card = data["cards"][0]
+    assert "_id" in first_card  # Oracle ID
+    assert "name" in first_card
+    assert "card_count" in first_card
+    assert "cards" in first_card  # Array of all printings
+
+    # Validate card_count matches number of printings
+    assert len(first_card["cards"]) == first_card["card_count"]
+
+    # Validate cursor structure (should be "score:oracle_id" or None)
+    if data["cursor"] is not None:
+        assert isinstance(data["cursor"], str)
+        # Cursor format is "score:oracle_id"
+        assert ":" in data["cursor"] or data["cursor"] == ""
+
+    # Validate has_more is boolean
+    assert isinstance(data["has_more"], bool)
+
+
+@pytest.mark.integration
+def test_sets_response_structure(test_client):
+    """Validate sets endpoint returns alphabetically sorted array of strings.
+
+    Tests that the /sets endpoint returns a list of set names as strings,
+    sorted alphabetically.
+    """
+    # Get all sets
+    response = test_client.get("/sets")
+    assert response.status_code == 200
+
+    data = response.json()
+
+    # Response is a dict with "sets" key containing the array
+    assert isinstance(data, dict)
+    assert "sets" in data
+
+    sets = data["sets"]
+
+    # Use assertion helper to validate sets structure
+    assert_valid_sets_response(sets)
+
+    # Validate we have some sets (test data has at least 2 unique sets)
+    assert len(sets) >= 2
+
+    # All elements should be non-empty strings
+    for set_name in sets:
+        assert isinstance(set_name, str)
+        assert len(set_name) > 0
+
+    # Verify alphabetical sorting
+    assert sets == sorted(sets)

--- a/tests/api/router/test_sets_integration.py
+++ b/tests/api/router/test_sets_integration.py
@@ -68,22 +68,22 @@ def test_get_sets_empty_database_returns_empty_list(test_client_empty):
 
 
 @pytest.mark.integration
-def test_get_sets_returns_alphabetically_sorted_descending(test_client):
-    """Test that /sets endpoint returns sets sorted Z→A alphabetically.
+def test_get_sets_returns_alphabetically_sorted_ascending(test_client):
+    """Test that /sets endpoint returns sets sorted A→Z alphabetically.
 
     This test validates that:
-    - MongoDB $sort stage with _id: -1 works correctly
-    - Sets are in descending alphabetical order
+    - MongoDB $sort stage with _id: 1 works correctly
+    - Sets are in ascending alphabetical order
     - Order is consistent across calls
 
-    Expected order (Z→A):
-    1. Rise of the Eldrazi
-    2. Return to Ravnica
-    3. Magic 2011
+    Expected order (A→Z):
+    1. Conflux
+    2. Double Masters
+    3. Innistrad
     4. Limited Edition Alpha
-    5. Innistrad
-    6. Double Masters
-    7. Conflux
+    5. Magic 2011
+    6. Return to Ravnica
+    7. Rise of the Eldrazi
     """
     response = test_client.get("/sets")
 
@@ -95,5 +95,5 @@ def test_get_sets_returns_alphabetically_sorted_descending(test_client):
     # Verify we have all 7 sets (updated with Phase 5 fixtures)
     assert len(sets) == 7
 
-    # Alternative verification: ensure list is sorted in descending order
-    assert sets == sorted(sets, reverse=True)
+    # Verify list is sorted in ascending (alphabetical) order
+    assert sets == sorted(sets)

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,27 @@
+"""Test utilities for MTG API integration tests.
+
+This package provides reusable assertion helpers and test data builders
+to reduce code duplication and improve test maintainability.
+"""
+
+from .assertions import (
+    assert_card_has_fields,
+    assert_valid_aggregated_card,
+    assert_valid_card_response,
+    assert_valid_image_uris,
+    assert_valid_search_response,
+    assert_valid_sets_response,
+    assert_valid_uuid,
+)
+from .builders import CardBuilder
+
+__all__ = [
+    "assert_card_has_fields",
+    "assert_valid_aggregated_card",
+    "assert_valid_card_response",
+    "assert_valid_image_uris",
+    "assert_valid_search_response",
+    "assert_valid_sets_response",
+    "assert_valid_uuid",
+    "CardBuilder",
+]

--- a/tests/utils/assertions.py
+++ b/tests/utils/assertions.py
@@ -1,0 +1,216 @@
+"""Assertion helpers for MTG API integration tests.
+
+This module provides reusable assertion functions to validate API response
+structures and reduce code duplication across test files.
+"""
+
+import re
+
+
+def assert_valid_uuid(value: str, field_name: str = "field") -> None:
+    """Validate that a value is a properly formatted UUID.
+
+    Args:
+        value: The value to validate as a UUID
+        field_name: Name of the field being validated (for error messages)
+
+    Raises:
+        AssertionError: If the value is not a valid UUID format
+    """
+    uuid_pattern = re.compile(
+        r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
+    )
+    assert isinstance(value, str), f"{field_name} must be a string, got {type(value)}"
+    assert uuid_pattern.match(value), (
+        f"{field_name} is not a valid UUID format: {value}"
+    )
+
+
+def assert_card_has_fields(card: dict, fields: list[str]) -> None:
+    """Validate that a card dictionary contains all specified fields.
+
+    Args:
+        card: The card dictionary to validate
+        fields: List of field names that must be present
+
+    Raises:
+        AssertionError: If any required field is missing
+    """
+    assert isinstance(card, dict), f"Card must be a dict, got {type(card)}"
+    for field in fields:
+        assert field in card, f"Card missing required field: {field}"
+
+
+def assert_valid_image_uris(image_uris: dict) -> None:
+    """Validate that image_uris contains all 6 required variants.
+
+    Args:
+        image_uris: The image_uris dictionary to validate
+
+    Raises:
+        AssertionError: If any required variant is missing or invalid
+    """
+    assert isinstance(image_uris, dict), (
+        f"image_uris must be a dict, got {type(image_uris)}"
+    )
+
+    required_variants = ["small", "normal", "large", "png", "art_crop", "border_crop"]
+    for variant in required_variants:
+        assert variant in image_uris, f"image_uris missing required variant: {variant}"
+        uri = image_uris[variant]
+        assert isinstance(uri, str), f"image_uris[{variant}] must be string"
+        assert uri.startswith(("http://", "https://")), (
+            f"image_uris[{variant}] must be a valid URL: {uri}"
+        )
+
+
+def assert_valid_card_response(card: dict) -> None:
+    """Validate that a card response includes all required PrintedCard fields.
+
+    This validates the complete structure returned by card endpoints like
+    /cards/id/{scryfall_id} or /cards/{name}.
+
+    Args:
+        card: The card dictionary to validate
+
+    Raises:
+        AssertionError: If any required field is missing or has wrong type
+    """
+    # Core identification fields (always required)
+    core_fields = ["id", "oracle_id", "name", "lang"]
+    assert_card_has_fields(card, core_fields)
+
+    # Validate UUID formats
+    assert_valid_uuid(card["id"], "id")
+    assert_valid_uuid(card["oracle_id"], "oracle_id")
+
+    # Gameplay fields (usually present)
+    gameplay_fields = ["type_line", "cmc"]
+    assert_card_has_fields(card, gameplay_fields)
+    assert isinstance(card["cmc"], (int, float)), "cmc must be numeric"
+
+    # Colors must be a list (can be empty for colorless)
+    if "colors" in card:
+        assert isinstance(card["colors"], list), "colors must be a list"
+
+    # Set information fields
+    set_fields = ["set", "rarity"]
+    assert_card_has_fields(card, set_fields)
+
+    # Image URIs (validate structure if present)
+    if "image_uris" in card and card["image_uris"] is not None:
+        assert_valid_image_uris(card["image_uris"])
+
+    # Layout field
+    if "layout" in card:
+        assert isinstance(card["layout"], str), "layout must be a string"
+
+
+def assert_valid_search_response(data: dict, min_cards: int = 0) -> None:
+    """Validate the structure of a search endpoint response.
+
+    Validates responses from /cards/search/{text} endpoint.
+
+    Args:
+        data: The response data dictionary to validate
+        min_cards: Minimum number of cards expected in results (default: 0)
+
+    Raises:
+        AssertionError: If response structure is invalid
+    """
+    assert isinstance(data, dict), f"Response must be a dict, got {type(data)}"
+
+    # Required top-level fields
+    required_fields = ["cards", "cursor", "has_more"]
+    for field in required_fields:
+        assert field in data, f"Search response missing required field: {field}"
+
+    # Validate cards array
+    assert isinstance(data["cards"], list), "cards must be a list"
+    assert len(data["cards"]) >= min_cards, (
+        f"Expected at least {min_cards} cards, got {len(data['cards'])}"
+    )
+
+    # Validate cursor (can be None or string)
+    assert data["cursor"] is None or isinstance(data["cursor"], str), (
+        "cursor must be None or string"
+    )
+
+    # Validate has_more flag
+    assert isinstance(data["has_more"], bool), "has_more must be a boolean"
+
+    # Validate each aggregated card in results
+    for i, card in enumerate(data["cards"]):
+        assert_valid_aggregated_card(card, f"cards[{i}]")
+
+
+def assert_valid_aggregated_card(card: dict, context: str = "card") -> None:
+    """Validate the structure of an aggregated card in search results.
+
+    Search results group cards by oracle_id with all printings included.
+
+    Args:
+        card: The aggregated card dictionary to validate
+        context: Context string for error messages (e.g., "cards[0]")
+
+    Raises:
+        AssertionError: If aggregated card structure is invalid
+    """
+    assert isinstance(card, dict), f"{context} must be a dict, got {type(card)}"
+
+    # Required aggregation fields
+    required_fields = ["_id", "name", "card_count", "cards"]
+    for field in required_fields:
+        assert field in card, f"{context} missing required field: {field}"
+
+    # Validate _id is a UUID (oracle_id)
+    assert_valid_uuid(card["_id"], f"{context}._id")
+
+    # Validate name
+    assert isinstance(card["name"], str), f"{context}.name must be a string"
+
+    # Validate card_count
+    assert isinstance(card["card_count"], int), (
+        f"{context}.card_count must be an integer"
+    )
+    assert card["card_count"] > 0, f"{context}.card_count must be positive"
+
+    # Validate cards array (all printings)
+    assert isinstance(card["cards"], list), f"{context}.cards must be a list"
+    assert len(card["cards"]) == card["card_count"], (
+        f"{context}.cards length must match card_count"
+    )
+
+    # Validate each printing in the cards array
+    for i, printing in enumerate(card["cards"]):
+        # Each printing should have basic card fields
+        printing_context = f"{context}.cards[{i}]"
+        assert isinstance(printing, dict), (
+            f"{printing_context} must be a dict, got {type(printing)}"
+        )
+        assert "id" in printing, f"{printing_context} missing id field"
+        assert_valid_uuid(printing["id"], f"{printing_context}.id")
+
+
+def assert_valid_sets_response(sets: list) -> None:
+    """Validate the structure of the /sets endpoint response.
+
+    Args:
+        sets: The sets array to validate
+
+    Raises:
+        AssertionError: If sets response structure is invalid
+    """
+    assert isinstance(sets, list), f"Sets response must be a list, got {type(sets)}"
+
+    # Each set should be a string (set name)
+    for i, set_name in enumerate(sets):
+        assert isinstance(set_name, str), (
+            f"sets[{i}] must be a string, got {type(set_name)}"
+        )
+        assert len(set_name) > 0, f"sets[{i}] must not be empty"
+
+    # Verify alphabetical sorting if there are multiple sets
+    if len(sets) > 1:
+        sorted_sets = sorted(sets)
+        assert sets == sorted_sets, "Sets must be alphabetically sorted"

--- a/tests/utils/builders.py
+++ b/tests/utils/builders.py
@@ -1,0 +1,369 @@
+"""Builder pattern for creating test card objects.
+
+This module provides a fluent API for building test card dictionaries,
+reducing boilerplate code in test files.
+"""
+
+import uuid
+from typing import Any
+
+
+class CardBuilder:
+    """Fluent API builder for creating test MTG card objects.
+
+    Example:
+        card = (CardBuilder()
+                .with_name("Test Card")
+                .with_colors(["R", "U"])
+                .with_cmc(3)
+                .with_rarity("rare")
+                .build())
+    """
+
+    def __init__(self) -> None:
+        """Initialize a new CardBuilder with default values."""
+        self._card: dict[str, Any] = {
+            "id": str(uuid.uuid4()),
+            "oracle_id": str(uuid.uuid4()),
+            "name": "Test Card",
+            "lang": "en",
+            "mana_cost": "{1}{U}",
+            "cmc": 2,
+            "colors": ["U"],
+            "color_identity": ["U"],
+            "type_line": "Instant",
+            "oracle_text": "Test card text.",
+            "set": "TST",
+            "set_name": "Test Set",
+            "set_id": str(uuid.uuid4()),
+            "rarity": "common",
+            "released_at": "2024-01-01",
+            "artist": "Test Artist",
+            "layout": "normal",
+            "image_uris": {
+                "small": "https://example.com/small.jpg",
+                "normal": "https://example.com/normal.jpg",
+                "large": "https://example.com/large.jpg",
+                "png": "https://example.com/png.png",
+                "art_crop": "https://example.com/art_crop.jpg",
+                "border_crop": "https://example.com/border_crop.jpg",
+            },
+            "games": ["paper", "mtgo", "arena"],
+            "digital": False,
+            "promo": False,
+            "reprint": False,
+        }
+
+    def with_id(self, card_id: str) -> "CardBuilder":
+        """Set the Scryfall ID of the card.
+
+        Args:
+            card_id: The Scryfall UUID for the card
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["id"] = card_id
+        return self
+
+    def with_oracle_id(self, oracle_id: str) -> "CardBuilder":
+        """Set the Oracle ID of the card.
+
+        Args:
+            oracle_id: The Oracle UUID for the card concept
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["oracle_id"] = oracle_id
+        return self
+
+    def with_name(self, name: str) -> "CardBuilder":
+        """Set the name of the card.
+
+        Args:
+            name: The card name
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["name"] = name
+        return self
+
+    def with_lang(self, lang: str) -> "CardBuilder":
+        """Set the language of the card.
+
+        Args:
+            lang: Language code (e.g., 'en', 'fr', 'ja')
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["lang"] = lang
+        return self
+
+    def with_mana_cost(self, mana_cost: str) -> "CardBuilder":
+        """Set the mana cost of the card.
+
+        Args:
+            mana_cost: Mana cost in Scryfall format (e.g., '{2}{R}{R}')
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["mana_cost"] = mana_cost
+        return self
+
+    def with_cmc(self, cmc: int | float) -> "CardBuilder":
+        """Set the converted mana cost of the card.
+
+        Args:
+            cmc: Converted mana cost (0-15+)
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["cmc"] = cmc
+        return self
+
+    def with_colors(self, colors: list[str]) -> "CardBuilder":
+        """Set the colors of the card.
+
+        Args:
+            colors: List of color codes (e.g., ['W', 'U', 'B', 'R', 'G'])
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["colors"] = colors
+        self._card["color_identity"] = colors  # Usually the same
+        return self
+
+    def with_color_identity(self, color_identity: list[str]) -> "CardBuilder":
+        """Set the color identity of the card (for Commander format).
+
+        Args:
+            color_identity: List of color codes
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["color_identity"] = color_identity
+        return self
+
+    def with_type_line(self, type_line: str) -> "CardBuilder":
+        """Set the type line of the card.
+
+        Args:
+            type_line: Type line (e.g., 'Legendary Creature — Human Wizard')
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["type_line"] = type_line
+        return self
+
+    def with_oracle_text(self, oracle_text: str) -> "CardBuilder":
+        """Set the oracle text of the card.
+
+        Args:
+            oracle_text: Rules text of the card
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["oracle_text"] = oracle_text
+        return self
+
+    def with_set(self, set_code: str, set_name: str | None = None) -> "CardBuilder":
+        """Set the set code and optionally set name.
+
+        Args:
+            set_code: Three-letter set code (e.g., 'MH2')
+            set_name: Full set name (optional, defaults to set_code)
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["set"] = set_code
+        self._card["set_name"] = set_name or set_code
+        return self
+
+    def with_rarity(self, rarity: str) -> "CardBuilder":
+        """Set the rarity of the card.
+
+        Args:
+            rarity: One of 'common', 'uncommon', 'rare', 'mythic'
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["rarity"] = rarity
+        return self
+
+    def with_released_at(self, date: str) -> "CardBuilder":
+        """Set the release date of the card.
+
+        Args:
+            date: ISO date string (YYYY-MM-DD)
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["released_at"] = date
+        return self
+
+    def with_artist(self, artist: str) -> "CardBuilder":
+        """Set the artist of the card.
+
+        Args:
+            artist: Artist name
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["artist"] = artist
+        return self
+
+    def with_layout(self, layout: str) -> "CardBuilder":
+        """Set the layout of the card.
+
+        Args:
+            layout: Layout type (e.g., 'normal', 'transform', 'split')
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["layout"] = layout
+        return self
+
+    def with_image_uris(self, image_uris: dict[str, str]) -> "CardBuilder":
+        """Set the image URIs of the card.
+
+        Args:
+            image_uris: Dictionary with image variant URLs
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["image_uris"] = image_uris
+        return self
+
+    def with_power_toughness(self, power: str, toughness: str) -> "CardBuilder":
+        """Set power and toughness for creature cards.
+
+        Args:
+            power: Power value (can be *, X, or number)
+            toughness: Toughness value (can be *, X, or number)
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["power"] = power
+        self._card["toughness"] = toughness
+        return self
+
+    def with_loyalty(self, loyalty: str) -> "CardBuilder":
+        """Set loyalty for planeswalker cards.
+
+        Args:
+            loyalty: Starting loyalty value
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["loyalty"] = loyalty
+        return self
+
+    def colorless(self) -> "CardBuilder":
+        """Make this card colorless (empty colors array).
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["colors"] = []
+        self._card["color_identity"] = []
+        self._card["mana_cost"] = ""
+        return self
+
+    def five_color(self) -> "CardBuilder":
+        """Make this card five-color (WUBRG).
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["colors"] = ["W", "U", "B", "R", "G"]
+        self._card["color_identity"] = ["W", "U", "B", "R", "G"]
+        return self
+
+    def instant(self) -> "CardBuilder":
+        """Make this card an instant.
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["type_line"] = "Instant"
+        return self
+
+    def sorcery(self) -> "CardBuilder":
+        """Make this card a sorcery.
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["type_line"] = "Sorcery"
+        return self
+
+    def creature(self, power: str = "2", toughness: str = "2") -> "CardBuilder":
+        """Make this card a creature with optional power/toughness.
+
+        Args:
+            power: Power value (default: "2")
+            toughness: Toughness value (default: "2")
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["type_line"] = "Creature"
+        self._card["power"] = power
+        self._card["toughness"] = toughness
+        return self
+
+    def artifact(self) -> "CardBuilder":
+        """Make this card an artifact.
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["type_line"] = "Artifact"
+        return self
+
+    def enchantment(self) -> "CardBuilder":
+        """Make this card an enchantment.
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["type_line"] = "Enchantment"
+        return self
+
+    def planeswalker(self, loyalty: str = "3") -> "CardBuilder":
+        """Make this card a planeswalker with optional loyalty.
+
+        Args:
+            loyalty: Starting loyalty value (default: "3")
+
+        Returns:
+            Self for method chaining
+        """
+        self._card["type_line"] = "Planeswalker"
+        self._card["loyalty"] = loyalty
+        return self
+
+    def build(self) -> dict[str, Any]:
+        """Build and return the card dictionary.
+
+        Returns:
+            Complete card dictionary with all configured values
+        """
+        return self._card.copy()

--- a/tests/utils/test_assertions.py
+++ b/tests/utils/test_assertions.py
@@ -1,0 +1,320 @@
+"""Tests for assertion helper functions.
+
+This module tests that assertion helpers correctly validate data
+and raise appropriate errors for invalid inputs.
+"""
+
+import pytest
+
+from tests.utils.assertions import (
+    assert_card_has_fields,
+    assert_valid_aggregated_card,
+    assert_valid_card_response,
+    assert_valid_image_uris,
+    assert_valid_search_response,
+    assert_valid_sets_response,
+    assert_valid_uuid,
+)
+from tests.utils.builders import CardBuilder
+
+
+class TestAssertValidUuid:
+    """Test UUID validation helper."""
+
+    def test_valid_uuid_passes(self):
+        """Valid UUID should not raise."""
+        valid_uuid = "550c74d4-a843-4208-a3c2-c71e84a21979"
+        assert_valid_uuid(valid_uuid)  # Should not raise
+
+    def test_invalid_uuid_raises(self):
+        """Invalid UUID format should raise AssertionError."""
+        with pytest.raises(AssertionError, match="not a valid UUID format"):
+            assert_valid_uuid("not-a-uuid")
+
+    def test_non_string_raises(self):
+        """Non-string value should raise AssertionError."""
+        with pytest.raises(AssertionError, match="must be a string"):
+            assert_valid_uuid(12345)  # type: ignore
+
+
+class TestAssertCardHasFields:
+    """Test field existence validator."""
+
+    def test_all_fields_present_passes(self):
+        """Card with all required fields should not raise."""
+        card = {"name": "Test", "id": "123", "type": "Instant"}
+        assert_card_has_fields(card, ["name", "id", "type"])  # Should not raise
+
+    def test_missing_field_raises(self):
+        """Card missing required field should raise AssertionError."""
+        card = {"name": "Test", "id": "123"}
+        with pytest.raises(AssertionError, match="missing required field: type"):
+            assert_card_has_fields(card, ["name", "id", "type"])
+
+    def test_non_dict_raises(self):
+        """Non-dict value should raise AssertionError."""
+        with pytest.raises(AssertionError, match="must be a dict"):
+            assert_card_has_fields("not a dict", ["name"])  # type: ignore
+
+
+class TestAssertValidImageUris:
+    """Test image URIs structure validator."""
+
+    def test_complete_image_uris_passes(self):
+        """Valid image_uris with all 6 variants should not raise."""
+        image_uris = {
+            "small": "https://example.com/small.jpg",
+            "normal": "https://example.com/normal.jpg",
+            "large": "https://example.com/large.jpg",
+            "png": "https://example.com/card.png",
+            "art_crop": "https://example.com/art.jpg",
+            "border_crop": "https://example.com/border.jpg",
+        }
+        assert_valid_image_uris(image_uris)  # Should not raise
+
+    def test_missing_variant_raises(self):
+        """Missing image variant should raise AssertionError."""
+        image_uris = {
+            "small": "https://example.com/small.jpg",
+            "normal": "https://example.com/normal.jpg",
+            # Missing other variants
+        }
+        with pytest.raises(AssertionError, match="missing required variant"):
+            assert_valid_image_uris(image_uris)
+
+    def test_invalid_url_raises(self):
+        """Non-URL value should raise AssertionError."""
+        image_uris = {
+            "small": "not-a-url",
+            "normal": "https://example.com/normal.jpg",
+            "large": "https://example.com/large.jpg",
+            "png": "https://example.com/card.png",
+            "art_crop": "https://example.com/art.jpg",
+            "border_crop": "https://example.com/border.jpg",
+        }
+        with pytest.raises(AssertionError, match="must be a valid URL"):
+            assert_valid_image_uris(image_uris)
+
+    def test_non_dict_raises(self):
+        """Non-dict value should raise AssertionError."""
+        with pytest.raises(AssertionError, match="must be a dict"):
+            assert_valid_image_uris("not a dict")  # type: ignore
+
+
+class TestAssertValidCardResponse:
+    """Test card response validator."""
+
+    def test_valid_card_passes(self):
+        """Valid card with all required fields should not raise."""
+        card = CardBuilder().build()
+        assert_valid_card_response(card)  # Should not raise
+
+    def test_missing_core_field_raises(self):
+        """Card missing core field should raise AssertionError."""
+        card = CardBuilder().build()
+        del card["name"]
+        with pytest.raises(AssertionError, match="missing required field: name"):
+            assert_valid_card_response(card)
+
+    def test_invalid_uuid_raises(self):
+        """Card with invalid UUID should raise AssertionError."""
+        card = CardBuilder().with_id("not-a-uuid").build()
+        with pytest.raises(AssertionError, match="not a valid UUID format"):
+            assert_valid_card_response(card)
+
+    def test_invalid_cmc_type_raises(self):
+        """Card with non-numeric CMC should raise AssertionError."""
+        card = CardBuilder().build()
+        card["cmc"] = "not a number"
+        with pytest.raises(AssertionError, match="cmc must be numeric"):
+            assert_valid_card_response(card)
+
+    def test_invalid_colors_type_raises(self):
+        """Card with non-list colors should raise AssertionError."""
+        card = CardBuilder().build()
+        card["colors"] = "R"  # Should be ["R"]
+        with pytest.raises(AssertionError, match="colors must be a list"):
+            assert_valid_card_response(card)
+
+    def test_colorless_card_passes(self):
+        """Colorless card with empty colors array should not raise."""
+        card = CardBuilder().colorless().build()
+        assert_valid_card_response(card)  # Should not raise
+
+    def test_invalid_image_uris_raises(self):
+        """Card with invalid image_uris should raise AssertionError."""
+        card = (
+            CardBuilder()
+            .with_image_uris(
+                {
+                    "small": "https://example.com/small.jpg",
+                    "normal": "https://example.com/normal.jpg",
+                    # Missing other required variants
+                }
+            )
+            .build()
+        )
+        with pytest.raises(AssertionError, match="missing required variant"):
+            assert_valid_card_response(card)
+
+
+class TestAssertValidSearchResponse:
+    """Test search response validator."""
+
+    def test_valid_search_response_passes(self):
+        """Valid search response should not raise."""
+        response = {
+            "cards": [
+                {
+                    "_id": "550c74d4-a843-4208-a3c2-c71e84a21979",
+                    "name": "Lightning Bolt",
+                    "card_count": 1,
+                    "cards": [
+                        {
+                            "id": "550c74d4-a843-4208-a3c2-c71e84a21979",
+                            "name": "Lightning Bolt",
+                        }
+                    ],
+                }
+            ],
+            "cursor": "score:oracle_id",
+            "has_more": False,
+        }
+        assert_valid_search_response(response)  # Should not raise
+
+    def test_empty_cards_array_passes(self):
+        """Empty cards array should not raise."""
+        response = {"cards": [], "cursor": None, "has_more": False}
+        assert_valid_search_response(response)  # Should not raise
+
+    def test_missing_field_raises(self):
+        """Missing required field should raise AssertionError."""
+        response = {"cards": [], "cursor": None}  # Missing has_more
+        with pytest.raises(AssertionError, match="missing required field"):
+            assert_valid_search_response(response)
+
+    def test_invalid_cards_type_raises(self):
+        """Non-list cards should raise AssertionError."""
+        response = {"cards": "not a list", "cursor": None, "has_more": False}
+        with pytest.raises(AssertionError, match="cards must be a list"):
+            assert_valid_search_response(response)
+
+    def test_invalid_has_more_type_raises(self):
+        """Non-boolean has_more should raise AssertionError."""
+        response = {"cards": [], "cursor": None, "has_more": "yes"}
+        with pytest.raises(AssertionError, match="has_more must be a boolean"):
+            assert_valid_search_response(response)
+
+    def test_min_cards_validation(self):
+        """Should validate minimum number of cards."""
+        response = {"cards": [], "cursor": None, "has_more": False}
+        with pytest.raises(AssertionError, match="Expected at least 1 cards"):
+            assert_valid_search_response(response, min_cards=1)
+
+
+class TestAssertValidAggregatedCard:
+    """Test aggregated card validator."""
+
+    def test_valid_aggregated_card_passes(self):
+        """Valid aggregated card should not raise."""
+        card = {
+            "_id": "550c74d4-a843-4208-a3c2-c71e84a21979",
+            "name": "Lightning Bolt",
+            "card_count": 2,
+            "cards": [
+                {
+                    "id": "550c74d4-a843-4208-a3c2-c71e84a21979",
+                    "name": "Lightning Bolt",
+                },
+                {
+                    "id": "a1234567-1234-1234-1234-123456789abc",
+                    "name": "Lightning Bolt",
+                },
+            ],
+        }
+        assert_valid_aggregated_card(card)  # Should not raise
+
+    def test_missing_field_raises(self):
+        """Missing required field should raise AssertionError."""
+        card = {
+            "_id": "550c74d4-a843-4208-a3c2-c71e84a21979",
+            "name": "Lightning Bolt",
+            # Missing card_count and cards
+        }
+        with pytest.raises(AssertionError, match="missing required field"):
+            assert_valid_aggregated_card(card)
+
+    def test_invalid_oracle_id_raises(self):
+        """Invalid oracle_id (_id) should raise AssertionError."""
+        card = {
+            "_id": "not-a-uuid",
+            "name": "Lightning Bolt",
+            "card_count": 1,
+            "cards": [{"id": "550c74d4-a843-4208-a3c2-c71e84a21979"}],
+        }
+        with pytest.raises(AssertionError, match="not a valid UUID format"):
+            assert_valid_aggregated_card(card)
+
+    def test_mismatched_count_raises(self):
+        """Mismatched card_count and cards length should raise AssertionError."""
+        card = {
+            "_id": "550c74d4-a843-4208-a3c2-c71e84a21979",
+            "name": "Lightning Bolt",
+            "card_count": 5,  # Says 5 but only has 1
+            "cards": [{"id": "550c74d4-a843-4208-a3c2-c71e84a21979"}],
+        }
+        with pytest.raises(AssertionError, match="length must match card_count"):
+            assert_valid_aggregated_card(card)
+
+    def test_invalid_printing_id_raises(self):
+        """Invalid printing ID should raise AssertionError."""
+        card = {
+            "_id": "550c74d4-a843-4208-a3c2-c71e84a21979",
+            "name": "Lightning Bolt",
+            "card_count": 1,
+            "cards": [{"id": "not-a-uuid"}],
+        }
+        with pytest.raises(AssertionError, match="not a valid UUID format"):
+            assert_valid_aggregated_card(card)
+
+
+class TestAssertValidSetsResponse:
+    """Test sets response validator."""
+
+    def test_valid_sets_passes(self):
+        """Valid sets array should not raise."""
+        sets = ["Alpha", "Beta", "Gamma"]
+        assert_valid_sets_response(sets)  # Should not raise
+
+    def test_empty_sets_passes(self):
+        """Empty sets array should not raise."""
+        sets = []
+        assert_valid_sets_response(sets)  # Should not raise
+
+    def test_non_list_raises(self):
+        """Non-list value should raise AssertionError."""
+        with pytest.raises(AssertionError, match="must be a list"):
+            assert_valid_sets_response("not a list")  # type: ignore
+
+    def test_non_string_element_raises(self):
+        """Non-string element should raise AssertionError."""
+        sets = ["Alpha", 123, "Gamma"]
+        with pytest.raises(AssertionError, match="must be a string"):
+            assert_valid_sets_response(sets)
+
+    def test_empty_string_raises(self):
+        """Empty string element should raise AssertionError."""
+        sets = ["Alpha", "", "Gamma"]
+        with pytest.raises(AssertionError, match="must not be empty"):
+            assert_valid_sets_response(sets)
+
+    def test_unsorted_sets_raises(self):
+        """Unsorted sets should raise AssertionError."""
+        sets = ["Zebra", "Alpha", "Beta"]  # Not alphabetical
+        with pytest.raises(AssertionError, match="must be alphabetically sorted"):
+            assert_valid_sets_response(sets)
+
+    def test_sorted_sets_passes(self):
+        """Alphabetically sorted sets should not raise."""
+        sets = ["Alpha", "Beta", "Gamma", "Zebra"]
+        assert_valid_sets_response(sets)  # Should not raise

--- a/tests/utils/test_builders.py
+++ b/tests/utils/test_builders.py
@@ -1,0 +1,304 @@
+"""Tests for CardBuilder test data builder.
+
+This module tests that the CardBuilder fluent API correctly
+constructs test card objects.
+"""
+
+from tests.utils.builders import CardBuilder
+
+
+class TestCardBuilderDefaults:
+    """Test default card construction."""
+
+    def test_default_build_creates_valid_card(self):
+        """Default build should create a card with all required fields."""
+        card = CardBuilder().build()
+
+        # Core fields
+        assert "id" in card
+        assert "oracle_id" in card
+        assert "name" in card
+        assert card["name"] == "Test Card"
+
+        # Gameplay fields
+        assert card["cmc"] == 2
+        assert card["colors"] == ["U"]
+        assert card["type_line"] == "Instant"
+
+        # Set info
+        assert card["set"] == "TST"
+        assert card["rarity"] == "common"
+
+        # Image URIs
+        assert "image_uris" in card
+        assert len(card["image_uris"]) == 6
+
+    def test_build_returns_copy(self):
+        """Build should return a copy, not the internal dict."""
+        builder = CardBuilder()
+        card1 = builder.build()
+        card2 = builder.build()
+
+        # Modifying one shouldn't affect the other
+        card1["name"] = "Modified"
+        assert card2["name"] == "Test Card"
+
+
+class TestCardBuilderFluentApi:
+    """Test fluent API methods."""
+
+    def test_with_name(self):
+        """Should set card name."""
+        card = CardBuilder().with_name("Lightning Bolt").build()
+        assert card["name"] == "Lightning Bolt"
+
+    def test_with_colors(self):
+        """Should set card colors and color identity."""
+        card = CardBuilder().with_colors(["R", "U"]).build()
+        assert card["colors"] == ["R", "U"]
+        assert card["color_identity"] == ["R", "U"]
+
+    def test_with_cmc(self):
+        """Should set converted mana cost."""
+        card = CardBuilder().with_cmc(5).build()
+        assert card["cmc"] == 5
+
+    def test_with_cmc_float(self):
+        """Should accept float CMC."""
+        card = CardBuilder().with_cmc(2.5).build()
+        assert card["cmc"] == 2.5
+
+    def test_with_rarity(self):
+        """Should set rarity."""
+        card = CardBuilder().with_rarity("mythic").build()
+        assert card["rarity"] == "mythic"
+
+    def test_with_type_line(self):
+        """Should set type line."""
+        card = CardBuilder().with_type_line("Legendary Creature — Dragon").build()
+        assert card["type_line"] == "Legendary Creature — Dragon"
+
+    def test_with_set(self):
+        """Should set set code and name."""
+        card = CardBuilder().with_set("MH2", "Modern Horizons 2").build()
+        assert card["set"] == "MH2"
+        assert card["set_name"] == "Modern Horizons 2"
+
+    def test_with_set_defaults_name(self):
+        """Should default set_name to set code."""
+        card = CardBuilder().with_set("MH2").build()
+        assert card["set"] == "MH2"
+        assert card["set_name"] == "MH2"
+
+    def test_with_oracle_text(self):
+        """Should set oracle text."""
+        card = CardBuilder().with_oracle_text("Draw a card.").build()
+        assert card["oracle_text"] == "Draw a card."
+
+    def test_with_mana_cost(self):
+        """Should set mana cost."""
+        card = CardBuilder().with_mana_cost("{2}{R}{R}").build()
+        assert card["mana_cost"] == "{2}{R}{R}"
+
+    def test_with_lang(self):
+        """Should set language."""
+        card = CardBuilder().with_lang("fr").build()
+        assert card["lang"] == "fr"
+
+    def test_with_released_at(self):
+        """Should set release date."""
+        card = CardBuilder().with_released_at("2024-12-25").build()
+        assert card["released_at"] == "2024-12-25"
+
+    def test_with_artist(self):
+        """Should set artist."""
+        card = CardBuilder().with_artist("John Avon").build()
+        assert card["artist"] == "John Avon"
+
+    def test_with_layout(self):
+        """Should set layout."""
+        card = CardBuilder().with_layout("transform").build()
+        assert card["layout"] == "transform"
+
+    def test_with_image_uris(self):
+        """Should set custom image URIs."""
+        custom_uris = {
+            "small": "https://custom.com/small.jpg",
+            "normal": "https://custom.com/normal.jpg",
+            "large": "https://custom.com/large.jpg",
+            "png": "https://custom.com/card.png",
+            "art_crop": "https://custom.com/art.jpg",
+            "border_crop": "https://custom.com/border.jpg",
+        }
+        card = CardBuilder().with_image_uris(custom_uris).build()
+        assert card["image_uris"] == custom_uris
+
+    def test_with_power_toughness(self):
+        """Should set power and toughness for creatures."""
+        card = CardBuilder().with_power_toughness("3", "4").build()
+        assert card["power"] == "3"
+        assert card["toughness"] == "4"
+
+    def test_with_loyalty(self):
+        """Should set loyalty for planeswalkers."""
+        card = CardBuilder().with_loyalty("5").build()
+        assert card["loyalty"] == "5"
+
+
+class TestCardBuilderConvenienceMethods:
+    """Test convenience methods for common card types."""
+
+    def test_colorless(self):
+        """Should create colorless card."""
+        card = CardBuilder().colorless().build()
+        assert card["colors"] == []
+        assert card["color_identity"] == []
+        assert card["mana_cost"] == ""
+
+    def test_five_color(self):
+        """Should create five-color card."""
+        card = CardBuilder().five_color().build()
+        assert card["colors"] == ["W", "U", "B", "R", "G"]
+        assert card["color_identity"] == ["W", "U", "B", "R", "G"]
+
+    def test_instant(self):
+        """Should create instant."""
+        card = CardBuilder().instant().build()
+        assert card["type_line"] == "Instant"
+
+    def test_sorcery(self):
+        """Should create sorcery."""
+        card = CardBuilder().sorcery().build()
+        assert card["type_line"] == "Sorcery"
+
+    def test_creature(self):
+        """Should create creature with default P/T."""
+        card = CardBuilder().creature().build()
+        assert card["type_line"] == "Creature"
+        assert card["power"] == "2"
+        assert card["toughness"] == "2"
+
+    def test_creature_with_custom_pt(self):
+        """Should create creature with custom P/T."""
+        card = CardBuilder().creature(power="5", toughness="7").build()
+        assert card["type_line"] == "Creature"
+        assert card["power"] == "5"
+        assert card["toughness"] == "7"
+
+    def test_artifact(self):
+        """Should create artifact."""
+        card = CardBuilder().artifact().build()
+        assert card["type_line"] == "Artifact"
+
+    def test_enchantment(self):
+        """Should create enchantment."""
+        card = CardBuilder().enchantment().build()
+        assert card["type_line"] == "Enchantment"
+
+    def test_planeswalker(self):
+        """Should create planeswalker with default loyalty."""
+        card = CardBuilder().planeswalker().build()
+        assert card["type_line"] == "Planeswalker"
+        assert card["loyalty"] == "3"
+
+    def test_planeswalker_with_custom_loyalty(self):
+        """Should create planeswalker with custom loyalty."""
+        card = CardBuilder().planeswalker(loyalty="6").build()
+        assert card["type_line"] == "Planeswalker"
+        assert card["loyalty"] == "6"
+
+
+class TestCardBuilderChaining:
+    """Test method chaining capabilities."""
+
+    def test_method_chaining(self):
+        """Should support chaining multiple methods."""
+        card = (
+            CardBuilder()
+            .with_name("Chained Card")
+            .with_colors(["R", "G"])
+            .with_cmc(4)
+            .with_rarity("rare")
+            .creature(power="4", toughness="4")
+            .build()
+        )
+
+        assert card["name"] == "Chained Card"
+        assert card["colors"] == ["R", "G"]
+        assert card["cmc"] == 4
+        assert card["rarity"] == "rare"
+        assert card["type_line"] == "Creature"
+        assert card["power"] == "4"
+
+    def test_complex_chaining(self):
+        """Should support complex method chains."""
+        card = (
+            CardBuilder()
+            .with_name("Complex Card")
+            .with_oracle_id("550c74d4-a843-4208-a3c2-c71e84a21979")
+            .with_colors(["W", "U", "B"])
+            .with_cmc(6)
+            .with_type_line("Legendary Creature — Angel")
+            .with_rarity("mythic")
+            .with_set("MH2", "Modern Horizons 2")
+            .with_power_toughness("5", "5")
+            .build()
+        )
+
+        assert card["name"] == "Complex Card"
+        assert card["oracle_id"] == "550c74d4-a843-4208-a3c2-c71e84a21979"
+        assert card["colors"] == ["W", "U", "B"]
+        assert card["cmc"] == 6
+        assert card["set"] == "MH2"
+        assert card["power"] == "5"
+
+
+class TestCardBuilderEdgeCases:
+    """Test edge cases and special scenarios."""
+
+    def test_colorless_artifact(self):
+        """Should create colorless artifact."""
+        card = (
+            CardBuilder()
+            .colorless()
+            .artifact()
+            .with_name("Sol Ring")
+            .with_cmc(1)
+            .build()
+        )
+
+        assert card["name"] == "Sol Ring"
+        assert card["colors"] == []
+        assert card["type_line"] == "Artifact"
+        assert card["cmc"] == 1
+
+    def test_five_color_legendary(self):
+        """Should create five-color legendary creature."""
+        card = (
+            CardBuilder()
+            .five_color()
+            .with_name("Progenitus")
+            .with_type_line("Legendary Creature — Hydra Avatar")
+            .with_cmc(10)
+            .with_power_toughness("10", "10")
+            .with_rarity("mythic")
+            .build()
+        )
+
+        assert card["name"] == "Progenitus"
+        assert card["colors"] == ["W", "U", "B", "R", "G"]
+        assert card["cmc"] == 10
+        assert card["power"] == "10"
+
+    def test_zero_cmc(self):
+        """Should support zero CMC."""
+        card = CardBuilder().with_name("Black Lotus").colorless().with_cmc(0).build()
+
+        assert card["name"] == "Black Lotus"
+        assert card["cmc"] == 0
+        assert card["colors"] == []
+
+    def test_high_cmc(self):
+        """Should support very high CMC."""
+        card = CardBuilder().with_name("Emrakul").with_cmc(15).build()
+        assert card["cmc"] == 15

--- a/web-app/.dockerignore
+++ b/web-app/.dockerignore
@@ -1,0 +1,47 @@
+# Dependencies
+node_modules
+.pnpm-store
+
+# Build output
+.next
+out
+dist
+build
+
+# Testing
+coverage
+.nyc_output
+test-results
+playwright-report
+.vitest
+
+# Environment
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# Misc
+*.log
+.git
+.gitignore
+README.md

--- a/web-app/Dockerfile
+++ b/web-app/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:22-alpine AS builder
+FROM node:22-slim AS builder
 
 # Install pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate
@@ -19,7 +19,7 @@ COPY . .
 RUN pnpm run build
 
 # Production stage
-FROM node:22-alpine AS runner
+FROM node:22-slim AS runner
 
 # Install pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate

--- a/web-app/Dockerfile.dev
+++ b/web-app/Dockerfile.dev
@@ -2,7 +2,7 @@
 # This Dockerfile is used for local development with hot reload
 # It's referenced by docker-compose.override.yml
 
-FROM node:22-alpine AS development
+FROM node:22-slim AS development
 
 # Install pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -64,5 +64,9 @@
     "typescript": "^5.9.3",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^4.0.9"
+  },
+  "optionalDependencies": {
+    "@tailwindcss/oxide-linux-x64-gnu": "^4.0.14",
+    "lightningcss-linux-x64-gnu": "^1.30.2"
   }
 }

--- a/web-app/pnpm-lock.yaml
+++ b/web-app/pnpm-lock.yaml
@@ -108,6 +108,13 @@ importers:
       vitest:
         specifier: ^4.0.9
         version: 4.0.9(@types/node@24.10.1)(@vitest/ui@4.0.9)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)
+    optionalDependencies:
+      '@tailwindcss/oxide-linux-x64-gnu':
+        specifier: ^4.0.14
+        version: 4.1.17
+      lightningcss-linux-x64-gnu:
+        specifier: ^1.30.2
+        version: 1.30.2
 
 packages:
 
@@ -2561,6 +2568,7 @@ packages:
   next@16.0.3:
     resolution: {integrity: sha512-Ka0/iNBblPFcIubTA1Jjh6gvwqfjrGq1Y2MTI5lbjeLIAfmC+p5bQmojpRZqgHHVu5cG4+qdIiwXiBSm/8lZ3w==}
     engines: {node: '>=20.9.0'}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -3187,6 +3195,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}


### PR DESCRIPTION
## Summary

Fixes the `/sets` ordering, unbreaks the web-app Docker build on glibc-only native binaries, tightens the release workflow's buildcache refs, and adds shared test utilities with two new integration suites.

## Changes

**`fix(api)`: sort sets ascending** — `/sets` returned sets Z→A because the aggregation used `$sort: {_id: -1}`. Switched to ascending for a natural A→Z listing. The integration test was updated in lockstep.

**`ci(release)`: use `github.repository` for buildcache refs** — the cache paths were assembled from `github.repository_owner` plus a hardcoded `mtg-api`. Using `github.repository` directly keeps them correct through a repo rename and matches how `docker/metadata-action` already derives the image tags. Applied to all five images (api, app, web-app, huey, mcp). Same resolved string today — no behavior change.

**`fix(web-app)`: `node:22-alpine` → `node:22-slim`** — Tailwind's oxide engine and lightningcss ship prebuilt native binaries whose `linux-x64-gnu` variants need glibc, which alpine (musl) doesn't provide. Moves the builder, runner, and dev stages to slim and declares both binaries as `optionalDependencies`. Adds a `.dockerignore` to keep `node_modules`, `.next`, and `.git` out of the build context.

**`test(api)`: shared utilities + edge case coverage** — new `tests/utils` with reusable assertion helpers and a `CardBuilder`, both covered by their own unit tests. Two suites build on them: `test_edge_cases` (boundary conditions, e.g. colorless cards matched with the `exactly` operator) and `test_response_schemas` (every documented field present and correctly typed).

**`docs`**: testing guides and the integration-test planning notes.

## Testing

`84 passed` across the new and modified suites. `ruff check` and `ruff format --check` clean across 38 files; all pre-commit hooks pass.

## Note for reviewers

The `/sets` commit changes the public ordering of that endpoint's response. If the Streamlit app or web-app depends on the previous Z→A order anywhere — a default-selected first entry in a set dropdown, for instance — that behavior shifts. The tests only cover the API layer, so nothing here would catch it. I have not audited the two frontends for `/sets` consumers.
