### PR TITLE
fix(docker): repair mongodb volume ownership and harden db services

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -152,9 +152,44 @@ services:
       retries: 3
       start_period: 5s
 
+  # Init container: normalises volume ownership before MongoDB starts.
+  # The Bitnami image runs as uid 1001, gid 0. A volume carrying ownership
+  # from anywhere else - a restored backup, a host directory, or the official
+  # mongo image, which uses uid 999 - leaves mongod unable to write its data
+  # directory, and the container dies with "Permission denied".
+  # Runs to completion on every `up`; a no-op once ownership is correct.
+  db-init:
+    image: busybox:1.37
+    # Reassigning ownership of a volume owned by another uid requires root,
+    # so this is the one root container in the stack. It is stripped to the
+    # two capabilities that actually need: CHOWN to reassign ownership, and
+    # DAC_OVERRIDE to traverse directories whose mode would otherwise deny
+    # it. It holds no network and exits before mongod starts.
+    user: root
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+    security_opt:
+      - no-new-privileges:true
+    command: chown -R 1001:0 /bitnami/mongodb
+    volumes:
+      - cards_data:/bitnami/mongodb
+    network_mode: none
+    restart: "no"
+
   db:
     platform: linux/x86_64
     image: bitnamilegacy/mongodb:8.0.4
+    # mongod runs unprivileged as uid 1001, gid 0. Pinned explicitly rather
+    # than inherited from the image so the guarantee survives an image bump,
+    # and with no capabilities, since mongod needs none on port 27017.
+    user: "1001:0"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     restart: always
     networks:
       - dokploy-network
@@ -166,6 +201,9 @@ services:
       - MONGODB_USERNAME=root
       - MONGODB_PASSWORD=root
       - MONGODB_ROOT_PASSWORD=root
+    depends_on:
+      db-init:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "mongosh", "--eval", "db.runCommand('ping')"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,9 +157,44 @@ services:
       timeout: 10s
       retries: 3
       start_period: 5s
+  # Init container: normalises volume ownership before MongoDB starts.
+  # The Bitnami image runs as uid 1001, gid 0. A volume carrying ownership
+  # from anywhere else - a restored backup, a host directory, or the official
+  # mongo image, which uses uid 999 - leaves mongod unable to write its data
+  # directory, and the container dies with "Permission denied".
+  # Runs to completion on every `up`; a no-op once ownership is correct.
+  db-init:
+    image: busybox:1.37
+    # Reassigning ownership of a volume owned by another uid requires root,
+    # so this is the one root container in the stack. It is stripped to the
+    # two capabilities that actually need: CHOWN to reassign ownership, and
+    # DAC_OVERRIDE to traverse directories whose mode would otherwise deny
+    # it. It holds no network and exits before mongod starts.
+    user: root
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+    security_opt:
+      - no-new-privileges:true
+    command: chown -R 1001:0 /bitnami/mongodb
+    volumes:
+      - cards_data:/bitnami/mongodb
+    network_mode: none
+    restart: "no"
+
   db:
     platform: linux/x86_64
     image: bitnamilegacy/mongodb:8.0.4
+    # mongod runs unprivileged as uid 1001, gid 0. Pinned explicitly rather
+    # than inherited from the image so the guarantee survives an image bump,
+    # and with no capabilities, since mongod needs none on port 27017.
+    user: "1001:0"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     restart: always
     networks:
       - dokploy-network
@@ -171,6 +206,9 @@ services:
       - MONGODB_USERNAME=root
       - MONGODB_PASSWORD=root
       - MONGODB_ROOT_PASSWORD=root
+    depends_on:
+      db-init:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "mongosh", "--eval", "db.runCommand('ping')"]
       interval: 10s


### PR DESCRIPTION
## Summary

MongoDB failed to start with a permission error on the `cards_data` volume. This adds an init container that normalises volume ownership before `db` starts, and tightens the privilege posture of both services.

## The bug

The Bitnami image runs as **uid 1001, gid 0**. When the volume carries ownership from anywhere else — a restored backup, a host directory, or the official `mongo` image, which runs as **uid 999** — mongod cannot write its data directory and the container dies:

```
mkdir: cannot create directory '/bitnami/mongodb': Permission denied
```

Reproduced against a volume owned by `999:999 / drwxr-x---`, and confirmed fixed by a `chown -R 1001:0`, after which mongod starts and answers `ping = 1`.

Note a *fresh* volume is fine: `/bitnami/mongodb` is `drwxrwxr-x root:root`, and the container's gid 0 makes it group-writable. Only foreign ownership breaks it.

## Changes

**`db-init`** — chowns the volume to `1001:0`, wired via `depends_on: {condition: service_completed_successfully}` so compose waits for it to exit 0 before starting `db`. The chown is a no-op once ownership is correct, so repeat `up`s are cheap. Applied to both `docker-compose.yml` and `docker-compose.prod.yml`, which share the same service and volume.

**Privilege posture** — mongod already ran unprivileged as 1001; this makes that explicit and enforced rather than inherited:

| | `db` | `db-init` |
|---|---|---|
| user | `1001:0` (pinned) | `root` (unavoidable) |
| capabilities | **none** — `cap_drop: ALL` | `CHOWN`, `DAC_OVERRIDE` only |
| no-new-privileges | yes | yes |
| network | dokploy-network | `none` |

Pinning `user` on `db` means the guarantee survives an image bump or an override. mongod needs no capabilities, since 27017 is above the privileged port range — verified at runtime:

```
CapPrm: 0000000000000000
CapEff: 0000000000000000
CapBnd: 0000000000000000
```

Changing ownership of a volume owned by another uid requires root — Docker has no equivalent of Kubernetes' `fsGroup` — so `db-init` is the one root container. Its capability set was measured rather than assumed: with `cap_drop: ALL` the chown fails `Permission denied`; adding only `CHOWN` still fails; it needs `CHOWN` **and** `DAC_OVERRIDE` (the latter to traverse directories whose mode denies it). Those two are the floor.

## Testing

Starting from a deliberately broken `999:999 / drwxr-x---` volume, `docker compose up db`:

- `db-init` exits 0, `db` reaches **Healthy**
- ownership becomes `uid=1001 gid=0`
- authenticated insert returns `INSERTED: 1`, and `COUNT: 1` after a restart — writes work and data persists
- re-running is idempotent
- both compose files pass `docker compose config`

## Not included

`read_only: true` on the db filesystem. Bitnami's entrypoint writes outside the volume, so it needs `tmpfs` mounts and would likely break the container — worth doing separately with real testing rather than bundling here.
