### PR TITLE
fix: repair web-app and mcp healthchecks, and container home directories

### DIFF
--- a/api.dockerfile
+++ b/api.dockerfile
@@ -31,8 +31,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get install -y --no-install-recommends curl && \
     rm -rf /var/lib/apt/lists/*
 
-# Create non-root user
-RUN groupadd -r app && useradd -r -g app app
+# Create non-root user with a home directory. useradd -r alone records
+# /home/app as HOME without creating it, and /home is root-owned, so
+# anything writing under $HOME fails with "Permission denied".
+RUN groupadd -r app && useradd -r -g app -m -d /home/app app
 
 # Copy application from builder
 COPY --from=builder --chown=app:app /app /app

--- a/app.dockerfile
+++ b/app.dockerfile
@@ -31,8 +31,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get install -y --no-install-recommends curl && \
     rm -rf /var/lib/apt/lists/*
 
-# Create non-root user
-RUN groupadd -r app && useradd -r -g app app
+# Create non-root user with a home directory. useradd -r alone records
+# /home/app as HOME without creating it, and /home is root-owned, so
+# anything writing under $HOME - Streamlit's machine-id file, for one -
+# fails with "Permission denied: '/home/app'".
+RUN groupadd -r app && useradd -r -g app -m -d /home/app app
 
 # Copy application from builder
 COPY --from=builder --chown=app:app /app /app

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -90,7 +90,16 @@ services:
       api:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      # node, not curl: the node:22-slim base ships neither curl nor wget,
+      # so the previous check exited 127 and the container could never be
+      # healthy however well the app was running.
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://localhost:3000').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
       interval: 15s
       timeout: 5s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,16 @@ services:
       api:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      # node, not curl: the node:22-slim base ships neither curl nor wget,
+      # so the previous check exited 127 and the container could never be
+      # healthy however well the app was running.
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://localhost:3000').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
       interval: 15s
       timeout: 5s
       retries: 3

--- a/huey.dockerfile
+++ b/huey.dockerfile
@@ -31,8 +31,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get install -y --no-install-recommends procps && \
     rm -rf /var/lib/apt/lists/*
 
-# Create non-root user
-RUN groupadd -r app && useradd -r -g app app
+# Create non-root user with a home directory. useradd -r alone records
+# /home/app as HOME without creating it, and /home is root-owned, so
+# anything writing under $HOME fails with "Permission denied".
+RUN groupadd -r app && useradd -r -g app -m -d /home/app app
 
 # Copy application from builder
 COPY --from=builder --chown=app:app /app /app

--- a/mcp.dockerfile
+++ b/mcp.dockerfile
@@ -32,7 +32,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     rm -rf /var/lib/apt/lists/*
 
 # Create non-root user
-RUN groupadd -r mcp && useradd -r -g mcp mcp
+# useradd -r alone records /home/mcp as HOME without creating it, and
+# /home is root-owned, so anything writing under $HOME fails with
+# "Permission denied".
+RUN groupadd -r mcp && useradd -r -g mcp -m -d /home/mcp mcp
 
 # Copy application from builder
 COPY --from=builder --chown=mcp:mcp /app /app

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -2,8 +2,9 @@
 
 import os
 
-from fastapi import FastAPI
 from fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 # Initialize FastMCP server
 mcp = FastMCP(
@@ -20,25 +21,20 @@ mcp = FastMCP(
 # Resources auto-register via @mcp.resource() decorators
 from mcp_server.resources import cards  # noqa: E402, F401
 
-# Create a FastAPI app for health checks
-# FastMCP uses this internally for HTTP/SSE transport
-app = FastAPI()
 
-
-@app.get("/health")
-async def health_check() -> dict:
+# Health check endpoint, served alongside the MCP transport on /mcp.
+# custom_route registers directly on the app FastMCP serves; the previous
+# approach mounted a separate FastAPI app onto mcp._fastapi_app, an
+# attribute FastMCP does not expose, so the guard never fired and /health
+# returned 404.
+@mcp.custom_route("/health", methods=["GET"])
+async def health_check(request: Request) -> JSONResponse:
     """Health check endpoint for Docker container monitoring.
 
     Returns:
-        Status dictionary with "status": "ok"
+        JSON response with "status": "ok"
     """
-    return {"status": "ok"}
-
-
-# Mount health check to MCP app
-# This allows the Docker healthcheck to work while MCP handles /mcp endpoint
-if hasattr(mcp, "_fastapi_app"):
-    mcp._fastapi_app.mount("/health", app)
+    return JSONResponse({"status": "ok"})
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

Three unhealthy/crashing services, three unrelated causes. One commit each.

## 1. web-app permanently unhealthy, with no logs

`node:22-slim` ships **neither `curl` nor `wget`**, but the healthcheck was `curl -f http://localhost:3000`. The check exited **127** — command not found — so the container could never be healthy however well Next.js was running. No logs, because nothing was wrong with the app.

Fixed with `node`, which is guaranteed present, rather than installing curl and growing the image:

```yaml
test: ["CMD", "node", "-e", "fetch('http://localhost:3000').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
```

Not a regression from the recent alpine→slim switch: `node:22-alpine` has no `curl` either, so this was broken before.

## 2. mcp unhealthy — `GET /health` → 404

`mcp_server/server.py` built a FastAPI app for `/health` and mounted it behind:

```python
if hasattr(mcp, "_fastapi_app"):
    mcp._fastapi_app.mount("/health", app)
```

FastMCP does not expose `_fastapi_app` — confirmed `hasattr` is **always False** on fastmcp 2.11.3 — so the mount never ran and the route was dead code. Mounting was doubly wrong anyway: an app whose route is `/health`, mounted under the `/health` prefix, answers on `/health/health`.

Replaced with the supported API, `@mcp.custom_route("/health", methods=["GET"])`.

## 3. Streamlit crash: `PermissionError: '/home/app'`

```
File "streamlit/runtime/metrics_util.py", line 209, in _get_machine_id_v4
PermissionError: [Errno 13] Permission denied: '/home/app'
```

`useradd -r` creates a system user and records `/home/app` as `$HOME` **without creating the directory**. `/home` is root-owned `drwxr-xr-x`, so the non-root user can't create it, and Streamlit writes a machine-id file under `$HOME` on every session.

Fixed with `useradd -r -g app -m -d /home/app app`.

**Applied to all four images.** The identical pattern was in `api`, `huey` and `mcp` — latent rather than absent, surfacing the moment any library writes to `$HOME` for a cache, config, or credentials file.

## Testing

- old web-app check exits **127**; new one exits **0** against a live server and **1** against a dead port — verified both directions, since a check that always passes is as useless as one that never does
- real MCP server now logs `"GET /health HTTP/1.1" 200 OK`, body `{"status":"ok"}` (was `404 Not Found`)
- `useradd -r -m -d` verified to produce `drwx------ app app /home/app` with a successful write as that user
- `72 passed` (`tests/mcp_server`, `tests/api`); ruff check + format clean; both compose files pass `docker compose config`

## Verification caveat

The web-app and Streamlit fixes are verified at the mechanism level — in the base images, with the exact commands — not by rebuilding the full application images. The MCP fix was verified against the actually-running server.
