### PR TITLE
perf: cache card pages and bound the cache

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -81,6 +81,10 @@ services:
     restart: always
     networks:
       - dokploy-network
+    volumes:
+      # Next.js writes its ISR pages and fetch cache here. Without a mount it
+      # grows inside the container layer, unbounded and invisible.
+      - next_cache:/app/.next/cache
     ports:
       - "8080:3000"
     environment:
@@ -258,6 +262,20 @@ volumes:
   cards_data:
   huey_data:
   meili_data:
+  # tmpfs, because it is the only volume type Docker can actually put a size
+  # limit on: the local driver rejects a size option without a backing block
+  # device, so a disk-backed volume would grow without bound.
+  #
+  # The tradeoff is that this is RAM and it empties on restart. Both are
+  # acceptable for a cache that regenerates itself - the first request for
+  # each card repopulates it. Raise or lower the size to trade memory for
+  # cache hits; when it fills, Next.js simply stops caching new entries.
+  next_cache:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+      o: size=100m
 
 networks:
   dokploy-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,10 @@ services:
     restart: always
     networks:
       - dokploy-network
+    volumes:
+      # Next.js writes its ISR pages and fetch cache here. Without a mount it
+      # grows inside the container layer, unbounded and invisible.
+      - next_cache:/app/.next/cache
     ports:
       - "8080:3000"
     environment:
@@ -260,6 +264,20 @@ services:
 volumes:
   cards_data:
   huey_data:
+  # tmpfs, because it is the only volume type Docker can actually put a size
+  # limit on: the local driver rejects a size option without a backing block
+  # device, so a disk-backed volume would grow without bound.
+  #
+  # The tradeoff is that this is RAM and it empties on restart. Both are
+  # acceptable for a cache that regenerates itself - the first request for
+  # each card repopulates it. Raise or lower the size to trade memory for
+  # cache hits; when it fills, Next.js simply stops caching new entries.
+  next_cache:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+      o: size=100m
 
 networks:
   dokploy-network:

--- a/web-app/app/@modal/(.)card/[id]/page.tsx
+++ b/web-app/app/@modal/(.)card/[id]/page.tsx
@@ -8,6 +8,12 @@ import { getCardByOracleId } from "@/lib/api";
 // The fetch and the markup are still server-side; only the dialog shell is
 // client code. A refresh or a direct visit falls through to app/card/[id].
 
+export const revalidate = 3600;
+
+export async function generateStaticParams() {
+  return [];
+}
+
 interface CardModalProps {
   params: Promise<{ id: string }>;
 }

--- a/web-app/app/card/[id]/page.tsx
+++ b/web-app/app/card/[id]/page.tsx
@@ -9,6 +9,13 @@ import { getCardByOracleId } from "@/lib/api";
 // refresh, or a shared link resolves to - the modal in @modal is only an
 // interception of this route when navigating from the grid.
 
+export const revalidate = 3600;
+
+// Enables the full route cache for on-demand params.
+export async function generateStaticParams() {
+  return [];
+}
+
 interface CardPageProps {
   params: Promise<{ id: string }>;
 }

--- a/web-app/lib/api.ts
+++ b/web-app/lib/api.ts
@@ -67,6 +67,15 @@ function normaliseCard(raw: RawOracleCard): OracleCard {
 // API hostname does not leave the network.
 const API_BASE_URL = process.env.API_URL ?? "http://api:8000";
 
+// A card, aggregated across its printings, is effectively immutable: it only
+// changes when a new printing ships or oracle text is errata'd. Cache it for
+// an hour so a card is fetched once and served from the cache after that.
+//
+// Next.js does not cache fetches by default, so this has to be asked for. The
+// tag lets a single card be invalidated with revalidateTag() without waiting
+// out the hour.
+const CARD_REVALIDATE_SECONDS = 60 * 60;
+
 export async function searchCards(
   text: string,
   cursor?: string | null,
@@ -151,6 +160,10 @@ export async function getCardByOracleId(oracleId: string): Promise<OracleCard | 
       method: "GET",
       headers: {
         "Content-Type": "application/json",
+      },
+      next: {
+        revalidate: CARD_REVALIDATE_SECONDS,
+        tags: ["card", `card:${oracleId}`],
       },
     }
   );


### PR DESCRIPTION
## Summary

Caches card pages on two levels, and bounds the cache so it cannot grow without limit. Follows on from #16, which made these pages server-rendered in the first place.

A card aggregated across its printings only changes when a new printing ships or oracle text is errata'd, so it is worth caching hard.

## Data cache

The card fetch gets `revalidate: 3600` plus tags. Next.js does not cache `fetch` by default, so this has to be asked for. Measured against a stub API that counts requests:

| | API calls |
|---|---|
| 10 loads of a card page, before | **10** |
| 10 loads, after | **1** |

The tags allow `revalidateTag('card:<id>')` for one card or `revalidateTag('card')` for all, without waiting out the hour.

## HTML cache

The data cache alone still re-rendered the page on every request — the route stayed `ƒ` and answered `no-store`. Worth noting because it is easy to assume otherwise: **`revalidate` on its own does not enable the full route cache.** It also needs `generateStaticParams`, returning `[]` so pages generate on first visit rather than at build time.

With both:

```
build:    ƒ /card/[id]                                  →  ● /card/[id]
headers:  private, no-cache, no-store, max-age=0        →  s-maxage=3600, stale-while-revalidate=…
                                                           x-nextjs-cache: HIT
                                                           x-nextjs-prerender: 1
```

The page is now CDN-cacheable, where before it was explicitly `no-store`.

The intercepted modal route caches the same way. Next sets `Vary: rsc, next-router-state-tree, next-url, …`, so the direct page and the soft-navigation RSC payload live as separate cache entries rather than one evicting the other. Both measured as `HIT` on a production build.

Deliberately **not** cached:

- **search** — results must reflect current data
- **failed lookups** — verified 3 loads of an unknown card still make 3 API calls, so a card added later appears immediately rather than being negatively cached for an hour

## Storage

The cache was being written into the container layer, where it grew unbounded and invisible. It now mounts at `/app/.next/cache` — a path confirmed by running the standalone server and watching where it actually writes, not inferred — on a volume capped at **100m**.

**tmpfs is the only volume type Docker can size-limit.** The local driver rejects a size option without a backing block device:

```
$ docker volume create --driver local --opt o=size=10m sizetest
Error response from daemon: create sizetest: missing required option: "device"
```

so a disk-backed volume could not be bounded at all. With tmpfs the cap is real — a 150MB write into a 100m volume truncates at exactly 100MB and `df` reports `100%`.

The trade is that this is RAM and it empties on restart. Both are fine for a cache that regenerates itself, and 100m keeps it modest on a small machine while still holding the cards people actually look at; the long tail simply misses and re-fetches.

**A full cache costs hit rate, not availability.** Tested by making the cache unwritable: every route still returned 200 while Next.js logged `Failed to update prerender cache … EACCES` and carried on serving.

## Testing

- **30/30 e2e** against a production build with both card routes cached, including "should open card details dialog when clicking a card"
- **256** Python, **37** web-app unit tests
- biome, tsc clean; both compose files validate
- cache behaviour measured with a request-counting stub API rather than assumed

## Operational note

Staleness is now two-layered: HTML cached for an hour *and* the fetch beneath it. A card edit can take up to an hour to appear. `revalidateTag('card:<id>')` clears the data but not the rendered HTML — that needs `revalidatePath('/card/<id>')`.
