### PR TITLE
fix(docker): Huey volume ownership and Meilisearch startup window

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -290,17 +290,22 @@ services:
       interval: 15s
       timeout: 5s
       # Meilisearch opens its index before it binds the port, so a large one
-      # on a slow disk can take minutes to answer /health. start_period is
-      # the knob for that, not retries: a check that fails inside the window
-      # does not count against retries at all, it just leaves the container
-      # "starting". The old 20s meant three failures had already accumulated
-      # by ~65s and the container was declared unhealthy while still loading.
+      # on a slow disk answers /health late and gets declared unhealthy
+      # mid-load, taking down everything that waits on it.
       #
-      # Retries stay low on purpose. They govern steady state, so raising
-      # them to cover a slow boot would also delay noticing a meilisearch
-      # that dies later. 5 x 15s detects a genuine failure inside 75s.
+      # Two knobs bound that and they are not interchangeable: a check that
+      # fails inside start_period does not count against retries, it just
+      # leaves the container "starting". So start_period covers boot, and
+      # retries govern steady state once it is up.
+      #
+      # Kept deliberately tight for now - 20s + 5 x 15s is roughly 95s before
+      # unhealthy, against 65s before. A long start_period would hold the
+      # whole stack in "starting" on every deploy, including when Meilisearch
+      # is genuinely broken. If it still trips this, raise start_period
+      # rather than retries: retries would also delay noticing a Meilisearch
+      # that dies later.
       retries: 5
-      start_period: 180s
+      start_period: 20s
 
 volumes:
   cards_data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -289,8 +289,18 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:7700/health"]
       interval: 15s
       timeout: 5s
-      retries: 3
-      start_period: 20s
+      # Meilisearch opens its index before it binds the port, so a large one
+      # on a slow disk can take minutes to answer /health. start_period is
+      # the knob for that, not retries: a check that fails inside the window
+      # does not count against retries at all, it just leaves the container
+      # "starting". The old 20s meant three failures had already accumulated
+      # by ~65s and the container was declared unhealthy while still loading.
+      #
+      # Retries stay low on purpose. They govern steady state, so raising
+      # them to cover a slow boot would also delay noticing a meilisearch
+      # that dies later. 5 x 15s detects a genuine failure inside 75s.
+      retries: 5
+      start_period: 180s
 
 volumes:
   cards_data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -109,9 +109,41 @@ services:
       retries: 3
       start_period: 30s
 
+  # Init container: normalises volume ownership before Huey starts.
+  # Same failure as db-init, one image over. Huey keeps its task queue in a
+  # SQLite database on huey_data, and the consumer runs as uid 999. A volume
+  # created while the image still ran as root stays root-owned - Docker only
+  # adopts the image's ownership onto a volume that is still empty - so
+  # SQLite cannot create huey.db-wal beside the database and the consumer
+  # dies with "Permission denied". Directory ownership is what matters here,
+  # not the database file's: SQLite writes its WAL and journal as siblings.
+  # Runs to completion on every `up`; a no-op once ownership is correct.
+  huey-init:
+    image: busybox:1.37
+    user: root
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+    security_opt:
+      - no-new-privileges:true
+    command: chown -R 999:999 /app/db
+    volumes:
+      - huey_data:/app/db
+    network_mode: none
+    restart: "no"
+
   huey:
     platform: linux/x86_64
     image: ghcr.io/trofleb/mtg-api/huey:latest
+    # Pinned to the uid huey.dockerfile creates, so the guarantee survives an
+    # image bump and matches what huey-init chowns the volume to.
+    user: "999:999"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     restart: always
     networks:
       - dokploy-network
@@ -125,6 +157,8 @@ services:
       - UV_LINK_MODE=copy
       - UV_CACHE_DIR=/tmp/.uv-cache
     depends_on:
+      huey-init:
+        condition: service_completed_successfully
       db:
         condition: service_healthy
       cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,12 +105,44 @@ services:
       timeout: 5s
       retries: 3
       start_period: 30s
+  # Init container: normalises volume ownership before Huey starts.
+  # Same failure as db-init, one image over. Huey keeps its task queue in a
+  # SQLite database on huey_data, and the consumer runs as uid 999. A volume
+  # created while the image still ran as root stays root-owned - Docker only
+  # adopts the image's ownership onto a volume that is still empty - so
+  # SQLite cannot create huey.db-wal beside the database and the consumer
+  # dies with "Permission denied". Directory ownership is what matters here,
+  # not the database file's: SQLite writes its WAL and journal as siblings.
+  # Runs to completion on every `up`; a no-op once ownership is correct.
+  huey-init:
+    image: busybox:1.37
+    user: root
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+    security_opt:
+      - no-new-privileges:true
+    command: chown -R 999:999 /app/db
+    volumes:
+      - huey_data:/app/db
+    network_mode: none
+    restart: "no"
+
   huey:
     platform: linux/x86_64
     image: ghcr.io/trofleb/mtg-api/huey:latest
     build:
       context: .
       dockerfile: huey.dockerfile
+    # Pinned to the uid huey.dockerfile creates, so the guarantee survives an
+    # image bump and matches what huey-init chowns the volume to.
+    user: "999:999"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     restart: always
     networks:
       - dokploy-network
@@ -126,6 +158,8 @@ services:
       - UV_LINK_MODE=copy
       - UV_CACHE_DIR=/tmp/.uv-cache
     depends_on:
+      huey-init:
+        condition: service_completed_successfully
       db:
         condition: service_healthy
       cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -292,8 +292,18 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:7700/health"]
       interval: 15s
       timeout: 5s
-      retries: 3
-      start_period: 20s
+      # Meilisearch opens its index before it binds the port, so a large one
+      # on a slow disk can take minutes to answer /health. start_period is
+      # the knob for that, not retries: a check that fails inside the window
+      # does not count against retries at all, it just leaves the container
+      # "starting". The old 20s meant three failures had already accumulated
+      # by ~65s and the container was declared unhealthy while still loading.
+      #
+      # Retries stay low on purpose. They govern steady state, so raising
+      # them to cover a slow boot would also delay noticing a meilisearch
+      # that dies later. 5 x 15s detects a genuine failure inside 75s.
+      retries: 5
+      start_period: 180s
 
 volumes:
   cards_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -293,17 +293,22 @@ services:
       interval: 15s
       timeout: 5s
       # Meilisearch opens its index before it binds the port, so a large one
-      # on a slow disk can take minutes to answer /health. start_period is
-      # the knob for that, not retries: a check that fails inside the window
-      # does not count against retries at all, it just leaves the container
-      # "starting". The old 20s meant three failures had already accumulated
-      # by ~65s and the container was declared unhealthy while still loading.
+      # on a slow disk answers /health late and gets declared unhealthy
+      # mid-load, taking down everything that waits on it.
       #
-      # Retries stay low on purpose. They govern steady state, so raising
-      # them to cover a slow boot would also delay noticing a meilisearch
-      # that dies later. 5 x 15s detects a genuine failure inside 75s.
+      # Two knobs bound that and they are not interchangeable: a check that
+      # fails inside start_period does not count against retries, it just
+      # leaves the container "starting". So start_period covers boot, and
+      # retries govern steady state once it is up.
+      #
+      # Kept deliberately tight for now - 20s + 5 x 15s is roughly 95s before
+      # unhealthy, against 65s before. A long start_period would hold the
+      # whole stack in "starting" on every deploy, including when Meilisearch
+      # is genuinely broken. If it still trips this, raise start_period
+      # rather than retries: retries would also delay noticing a Meilisearch
+      # that dies later.
       retries: 5
-      start_period: 180s
+      start_period: 20s
 
 volumes:
   cards_data:

--- a/huey.dockerfile
+++ b/huey.dockerfile
@@ -34,7 +34,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # Create non-root user with a home directory. useradd -r alone records
 # /home/app as HOME without creating it, and /home is root-owned, so
 # anything writing under $HOME fails with "Permission denied".
-RUN groupadd -r app && useradd -r -g app -m -d /home/app app
+#
+# The uid/gid are pinned rather than left to useradd, which just takes the
+# next free system id. huey-init in docker-compose chowns the huey_data
+# volume to this exact id, so letting it drift - by adding another system
+# user above this line, or bumping the base image - would silently hand the
+# volume to the wrong owner and put back the bug this pinning prevents.
+RUN groupadd -r -g 999 app && useradd -r -u 999 -g app -m -d /home/app app
 
 # Copy application from builder
 COPY --from=builder --chown=app:app /app /app


### PR DESCRIPTION
Two deploy failures reported from the VPS: Huey unable to write its SQLite queue, and Meilisearch marked unhealthy — taking `api`, `app` and `web-app` down with it, since all three wait on it.

## Huey: root-owned data volume

The same bug as MongoDB, one image over. Docker only adopts the image directory's ownership onto a volume that is **still empty**. `huey_data` was created while the image ran as root, so it stayed root-owned when the Dockerfile switched to `USER app` (uid 999).

The subtle part is that it's the *directory* that matters, not `huey.db` — SQLite creates its WAL and journal as siblings, so a writable database file in a root-owned directory still fails.

Verified against the built image:

| | result |
|---|---|
| pre-existing root-owned volume | `sqlite3.OperationalError: attempt to write a readonly database` |
| after `huey-init` runs | `ENQUEUE OK` |

A fresh volume was never affected — Docker chowns an empty one to match the image — which is why this only bites an environment that has been deployed before, and won't reproduce on a clean local `up`.

Fixed with a `huey-init` busybox container mirroring `db-init`: `CHOWN` + `DAC_OVERRIDE` only, no network, `service_completed_successfully`. A no-op once ownership is correct.

The uid is now pinned in `huey.dockerfile`. `useradd -r` just takes the next free system id, so adding another system user above that line would shift `app` to 998 and silently hand the volume to the wrong owner — reintroducing exactly this bug.

## Meilisearch: widen the startup window, modestly

Meilisearch opens its index before binding the port, so a large one on a slow disk answers `/health` late and gets declared unhealthy mid-load.

The two knobs are not interchangeable, which is the useful part here. Verified against Docker with a check that **always fails**:

| | health status | failing streak |
|---|---|---|
| 40s into a 60s `start_period` | `starting` | 0 |
| after it elapsed | `unhealthy` | 14 |

Failures inside `start_period` don't count against `retries` at all. So `start_period` covers boot; `retries` governs steady state once it's up.

Settled on `retries: 5`, `start_period: 20s` — roughly 95s before unhealthy, against 65s before. An earlier commit in this branch tried `start_period: 180s`; that was backed out because a long start window is paid on *every* deploy, including ones where Meilisearch is genuinely broken, holding the whole stack in `starting` for three minutes before anything reports a problem. The slow-boot case it guards against is still unconfirmed.

If 95s proves too tight, raise `start_period` rather than `retries` — retries would also delay noticing a Meilisearch that dies after it is up.

Ruled out first, by testing rather than assuming: missing `curl` (present at `/usr/bin/curl`, unlike the `node:22-slim` base that broke web-app), an empty or absent `MEILI_MASTER_KEY` (starts fine either way), and the healthcheck command itself (exits 0 against a clean container).

## Caveat

The Meilisearch change is hypothesis-driven — I could not reach the VPS to confirm. It is a safe widening regardless, but if the real cause is a crash-loop or an OOM kill, a wider window only delays the same failure. To distinguish:

```
docker inspect --format 'exit={{.State.ExitCode}} oom={{.State.OOMKilled}} restarts={{.RestartCount}}' <meilisearch>
```

`OOMKilled` is worth checking first on a small machine — a SIGKILL leaves nothing in the logs, which matches "nothing evident in logs". One reproduction that also fits: `MEILI_HTTP_ADDR` reaching the container as a URL rather than a socket address exits 1 with "Name does not resolve", printing the normal banner first on each restart.

Note the retries bump made directly in Dokploy is not in git — this PR is what makes it survive the next deploy.

## Verification

- Both compose files validate; effective values confirmed via `compose config`
- Huey fix confirmed end-to-end against the real built image
- `start_period` semantics confirmed empirically, not assumed
- No Python or TypeScript touched