### PR TITLE
fix(web-app): load card art directly from Scryfall instead of the optimizer

### DIFF
--- a/web-app/next.config.ts
+++ b/web-app/next.config.ts
@@ -5,6 +5,21 @@ const nextConfig: NextConfig = {
   reactStrictMode: true,
   output: "standalone",
   images: {
+    // Card art is loaded straight from Scryfall's CDN instead of through
+    // /_next/image. Scryfall rejects requests whose User-Agent is "default
+    // or generic" with a 400, and Node's fetch sends "node" - so every
+    // optimizer request failed while the same URL loaded fine in a browser,
+    // which sends a real User-Agent. The optimizer offers no way to set an
+    // upstream header, so there is nothing to configure around it.
+    //
+    // Serving direct is the better trade here anyway: these are already
+    // right-sized JPEGs (~60KB) behind a CDN with a year-long cache-control,
+    // so proxying them would spend VPS CPU re-encoding and evict the ISR
+    // entries from the size-capped .next/cache for very little saving.
+    unoptimized: true,
+    // Unused while unoptimized is set, but kept deliberately: it records the
+    // one host card art may come from, and is what makes the optimizer legal
+    // again if it is ever re-enabled behind a proxy that sets a User-Agent.
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
Every card image on the deployed site failed with `400` from `/_next/image`.

## Cause

Scryfall rejects requests whose User-Agent is "default or generic", and says so in the response body:

```
400 Bad Request
Your User-Agent header is currently set to default or generic value.
```

Next's image optimizer fetches upstream with a bare `fetch()` — no headers set — so Node's undici sends `user-agent: node` and Scryfall refuses it.

This is why it looked like a config problem but wasn't. `remotePatterns` was correct all along; the optimizer got past the allowlist and failed at the fetch, which is what `"url" parameter is valid but upstream response is invalid` means. The same URL loads perfectly in a browser, which sends a real User-Agent — so the failure only ever existed server-side.

Ruled out along the way, by testing rather than assuming: the hostname allowlist (`matchRemotePattern` returns `true`, query string included), the `w`/`q` parameters (all within default `deviceSizes`/`imageSizes`, `q=75` is the default quality), and every plausible header difference — `Accept`, `Accept-Encoding`, HTTP/1.1 vs 2 all return `200` under curl, because curl sends its own User-Agent.

## Fix

The optimizer exposes no way to set an upstream request header, so there is nothing to configure around it. Set `images.unoptimized` and let the browser fetch Scryfall directly.

That is the better trade regardless. The art is already right-sized JPEGs (~60KB) behind a CDN with `cache-control: public, max-age=31556952`. Proxying it would spend VPS CPU re-encoding and evict ISR entries from the size-capped `.next/cache` for very little saving.

`remotePatterns` stays: unused while `unoptimized` is set, but it records the one host card art may come from, and is what makes the optimizer legal again if it is ever re-enabled behind a proxy that sets a User-Agent.

## Verification

Against a real production build served with a stub API:

| | before | after |
|---|---|---|
| `/_next/image` in page HTML | 9 per card | **0** |
| `srcset` entries | 9 | **0** |
| emitted `src` | `/_next/image?url=...` | `https://cards.scryfall.io/...` |

Both the grid (`/`) and the card detail page (`/card/[id]`) emit the direct URL, and that exact URL returns `200 image/jpeg 57782` to a browser User-Agent.

Also confirmed the build still reports `●` for `/card/[id]` and `/(.)card/[id]` — the full route cache from #17 is unaffected.

`pnpm lint` (4 warnings, all pre-existing — same count on a clean tree), `pnpm typecheck` clean, 37 unit tests pass.

## Note on test coverage

A component unit test cannot catch this class of bug: `vitest.setup.ts` mocks `next/image` to a plain `<img>`, so it never exercises the optimizer and would stay green either way. A Playwright assertion on image response status would be the real guard — worth adding when e2e runs in CI.