### PR TITLE
test(e2e): let the Playwright suite run against a deployed site

### DIFF
--- a/justfile
+++ b/justfile
@@ -149,6 +149,14 @@ test-e2e *args:
 test-e2e-ui:
     cd web-app && pnpm run test:e2e:ui
 
+# Run e2e tests against production (no local API or tunnel needed)
+test-e2e-prod *args:
+    cd web-app && pnpm run test:e2e:prod --reporter=list {{args}}
+
+# Interactive UI mode against production
+test-e2e-ui-prod:
+    cd web-app && pnpm run test:e2e:ui:prod
+
 # Debug mode with inspector
 test-e2e-debug:
     cd web-app && pnpm run test:e2e:debug

--- a/web-app/.gitignore
+++ b/web-app/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Ad-hoc exploration scripts (Playwright probes against a deployed site)
+.explore/

--- a/web-app/e2e/api.spec.ts
+++ b/web-app/e2e/api.spec.ts
@@ -3,6 +3,17 @@ import { expect, test } from "@playwright/test";
 const API_BASE_URL = process.env.API_URL || "http://localhost:8000";
 
 test.describe("MTG API Endpoints", () => {
+  // These talk to the API directly, which only works where the API is
+  // reachable: a local stack, or a VPS tunnel that publishes it on
+  // localhost. Production deliberately does not expose it - the browser can
+  // only ever reach the Next.js server - so against a remote BASE_URL these
+  // would fail for the very reason the deployment is considered correct.
+  // Skip rather than fail, and say so, so a red run always means a real bug.
+  test.skip(
+    () => Boolean(process.env.BASE_URL) && !process.env.API_URL,
+    "API is not exposed publicly; set API_URL (e.g. via the VPS tunnel) to run these"
+  );
+
   test("should respond to ping endpoint", async ({ request }) => {
     const response = await request.get(`${API_BASE_URL}/ping`);
 

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -22,7 +22,9 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:debug": "playwright test --debug",
-    "test:e2e:report": "playwright show-report"
+    "test:e2e:report": "playwright show-report",
+    "test:e2e:prod": "BASE_URL=https://mtg.nicocasa.ch playwright test",
+    "test:e2e:ui:prod": "BASE_URL=https://mtg.nicocasa.ch playwright test --ui"
   },
   "keywords": [],
   "author": "",

--- a/web-app/playwright.config.ts
+++ b/web-app/playwright.config.ts
@@ -64,13 +64,19 @@ export default defineConfig({
     // },
   ],
 
-  // Run your local dev server before starting the tests
-  webServer: {
-    command: process.env.CI ? "pnpm run build && pnpm run start" : "pnpm run dev",
-    url: "http://localhost:3000",
-    reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
-    stdout: "pipe",
-    stderr: "pipe",
-  },
+  // Run a local dev server before starting the tests - but only when the
+  // tests are aimed at localhost. With BASE_URL pointing somewhere else
+  // (production, a preview deploy) there is nothing to boot, and starting a
+  // local server anyway wastes two minutes and, worse, silently serves the
+  // local build on :3000 while the assertions run against the remote host.
+  webServer: process.env.BASE_URL
+    ? undefined
+    : {
+        command: process.env.CI ? "pnpm run build && pnpm run start" : "pnpm run dev",
+        url: "http://localhost:3000",
+        reuseExistingServer: !process.env.CI,
+        timeout: 120 * 1000,
+        stdout: "pipe",
+        stderr: "pipe",
+      },
 });


### PR DESCRIPTION
Groundwork for exploring the deployed app with Playwright. No application code changes.

## What was wrong

`baseURL` already read `BASE_URL`, so pointing the suite at production looked supported — but `webServer` started a local dev server unconditionally. Two problems:

1. Two minutes wasted booting a server nothing talks to.
2. Worse, a local build ends up serving on `:3000` while the assertions run against the remote host. A green run proves nothing about the deployment.

Now a server only starts when the target is localhost.

## The API tests

Ten tests in `api.spec.ts` call the API directly. Against production they all failed — but **that failure is the deployment working as designed**: the API is deliberately unreachable from the browser, which was the whole point of the SSR work. Failing there would mean a red suite forever, training everyone to ignore it.

They now skip with the reason stated, and still run normally against a local stack or a VPS tunnel (set `API_URL`).

## Result against production

```
19 passed, 10 skipped, 1 failed
```

The single failure is a genuine bug, filed separately: the first card tile on the default page renders `href="/card"` with no id and 404s on click.

```
card-item count: 20
first tile: { "tag": "A", "href": "/card" }
URL after click: https://mtg.nicocasa.ch/card
body: 404 | This page could not be found.
```

## Usage

```
just test-e2e-prod          # against https://mtg.nicocasa.ch
just test-e2e-ui-prod       # interactive
just test-e2e               # unchanged: local stack
```

`.explore/` is gitignored for ad-hoc probe scripts.